### PR TITLE
fix: deduplicate concurrent provider loads

### DIFF
--- a/src/providers/AGENTS.md
+++ b/src/providers/AGENTS.md
@@ -1,0 +1,16 @@
+# Provider layer
+
+## Scope
+
+Archive provider factories and concrete provider implementations. Root `../../AGENTS.md` remains authoritative.
+
+## Conventions
+
+- Provider factories may cache module-load promises, never configured provider instances.
+- Every factory call returns a fresh provider whose options belong only to that call.
+- A failed lazy import must remain retryable; clear its cached promise on rejection.
+- Keep provider-specific request and response behavior in the owning provider file.
+
+## Verification
+
+Run the focused provider-registry test, then typecheck, build, and the full test suite when changing lazy loading.

--- a/src/providers/_lazy-import.ts
+++ b/src/providers/_lazy-import.ts
@@ -1,0 +1,19 @@
+/**
+ * Wrap a dynamic import so concurrent callers share one in-flight module load.
+ * A rejected import is forgotten, allowing a later call to retry.
+ *
+ * @template T - Module namespace returned by the import.
+ * @param load - Dynamic import operation.
+ * @returns A retryable lazy loader.
+ */
+export function createRetryableLazyImport<T>(load: () => Promise<T>): () => Promise<T> {
+  let pending: Promise<T> | undefined;
+
+  return () => {
+    pending ??= load().catch((error: unknown) => {
+      pending = undefined;
+      throw error;
+    });
+    return pending;
+  };
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -9,6 +9,16 @@ import type {
   CommonCrawlOptions,
   WebCiteOptions,
 } from "../_providers";
+import { createRetryableLazyImport } from "./_lazy-import";
+
+const loadWaybackModule = createRetryableLazyImport(() => import("./wayback"));
+const loadArchiveItModule = createRetryableLazyImport(() => import("./archive-it"));
+const loadConiferModule = createRetryableLazyImport(() => import("./conifer"));
+const loadArchiveTodayModule = createRetryableLazyImport(() => import("./archive-today"));
+const loadMementoModule = createRetryableLazyImport(() => import("./memento"));
+const loadPermaccModule = createRetryableLazyImport(() => import("./permacc"));
+const loadCommonCrawlModule = createRetryableLazyImport(() => import("./commoncrawl"));
+const loadWebCiteModule = createRetryableLazyImport(() => import("./webcite"));
 
 /**
  * Provider factory with lazy-loading for optimized tree-shaking.
@@ -25,7 +35,7 @@ export const providers = {
    * ```
    */
   async wayback(options?: WaybackOptions): Promise<ArchiveProvider> {
-    const { WaybackProvider } = await import("./wayback");
+    const { WaybackProvider } = await loadWaybackModule();
     return new WaybackProvider(options);
   },
 
@@ -39,7 +49,7 @@ export const providers = {
    * ```
    */
   async archiveIt(options: ArchiveItOptions): Promise<ArchiveProvider> {
-    const { ArchiveItProvider } = await import("./archive-it");
+    const { ArchiveItProvider } = await loadArchiveItModule();
     return new ArchiveItProvider(options);
   },
 
@@ -53,7 +63,7 @@ export const providers = {
    * ```
    */
   async conifer(options: ConiferOptions): Promise<ArchiveProvider> {
-    const { ConiferProvider } = await import("./conifer");
+    const { ConiferProvider } = await loadConiferModule();
     return new ConiferProvider(options);
   },
 
@@ -67,13 +77,13 @@ export const providers = {
    * ```
    */
   async archiveToday(options?: ArchiveTodayOptions): Promise<ArchiveProvider> {
-    const { ArchiveTodayProvider } = await import("./archive-today");
+    const { ArchiveTodayProvider } = await loadArchiveTodayModule();
     return new ArchiveTodayProvider(options);
   },
 
   /** Creates a lazily loaded Memento provider that uses MemGator. */
   async memento(options?: MementoOptions): Promise<ArchiveProvider> {
-    const { MementoProvider } = await import("./memento");
+    const { MementoProvider } = await loadMementoModule();
     return new MementoProvider(options);
   },
 
@@ -87,7 +97,7 @@ export const providers = {
    * ```
    */
   async permacc(options?: Partial<PermaccOptions>): Promise<ArchiveProvider> {
-    const { PermaccProvider } = await import("./permacc");
+    const { PermaccProvider } = await loadPermaccModule();
     return new PermaccProvider(options);
   },
 
@@ -101,7 +111,7 @@ export const providers = {
    * ```
    */
   async commoncrawl(options?: CommonCrawlOptions): Promise<ArchiveProvider> {
-    const { CommonCrawlProvider } = await import("./commoncrawl");
+    const { CommonCrawlProvider } = await loadCommonCrawlModule();
     return new CommonCrawlProvider(options);
   },
 
@@ -115,7 +125,7 @@ export const providers = {
    * ```
    */
   async webcite(options?: WebCiteOptions): Promise<ArchiveProvider> {
-    const { WebCiteProvider } = await import("./webcite");
+    const { WebCiteProvider } = await loadWebCiteModule();
     return new WebCiteProvider(options);
   },
 

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,0 +1,16 @@
+# Test scope
+
+## Scope
+
+Vitest coverage for the archive library and its Pi, OMP, MCP, CLI, and provider seams. Root `../AGENTS.md` remains authoritative.
+
+## Conventions
+
+- Test observable behavior through public or intentionally internal module seams.
+- Keep tests deterministic and offline unless explicitly marked as live.
+- Concurrency regressions must prove the cold path and preserve independent instances/options.
+- Restore mocks, globals, environment values, caches, and resources in the same test lifecycle.
+
+## Verification
+
+Run the focused file first and the full suite after changes to module-level state or lazy loading.

--- a/test/provider-lazy-loading.test.ts
+++ b/test/provider-lazy-loading.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { createRetryableLazyImport } from "../src/providers/_lazy-import";
+
+describe("provider lazy loading", () => {
+  it("shares one in-flight module load across concurrent calls", async () => {
+    const deferred = Promise.withResolvers<{ readonly value: string }>();
+    let attempts = 0;
+    const load = createRetryableLazyImport(() => {
+      attempts += 1;
+      return deferred.promise;
+    });
+
+    const first = load();
+    const second = load();
+
+    expect(attempts).toBe(1);
+    expect(first).toBe(second);
+
+    deferred.resolve({ value: "loaded" });
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { value: "loaded" },
+      { value: "loaded" },
+    ]);
+  });
+
+  it("retries a module load after rejection", async () => {
+    const failure = new Error("load failed");
+    let attempts = 0;
+    const load = createRetryableLazyImport(async () => {
+      attempts += 1;
+      if (attempts === 1) throw failure;
+      return { value: "loaded" };
+    });
+
+    await expect(load()).rejects.toBe(failure);
+    await expect(load()).resolves.toEqual({ value: "loaded" });
+    expect(attempts).toBe(2);
+  });
+});

--- a/test/provider-registry-concurrency.test.ts
+++ b/test/provider-registry-concurrency.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.doUnmock("../src/providers/_lazy-import");
+  vi.resetModules();
+});
+
+describe("provider registry concurrency", () => {
+  it("loads a cold provider module once while keeping instances independent", async () => {
+    let importAttempts = 0;
+    vi.doMock("../src/providers/_lazy-import", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("../src/providers/_lazy-import")>();
+
+      return {
+        ...actual,
+        createRetryableLazyImport: <T>(load: () => Promise<T>) =>
+          actual.createRetryableLazyImport(() => {
+            importAttempts += 1;
+            return load();
+          }),
+      };
+    });
+
+    const { providers } = await import("../src/providers/index");
+    const [first, second] = await Promise.all([
+      providers.wayback({ limit: 1 }),
+      providers.wayback({ limit: 2 }),
+    ]);
+
+    expect(importAttempts).toBe(1);
+    expect(first).not.toBe(second);
+    expect(first.options?.limit).toBe(1);
+    expect(second.options?.limit).toBe(2);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     coverage: {
-      include: ["src"],
+      include: ["src/**/*.ts"],
       reporter: ["text", "json", "html"],
     },
   },


### PR DESCRIPTION
## Context

During concurrent cold archive calls, I observed one successful result while another failed with `WaybackProvider is not a constructor`; a warm retry succeeded. Each provider factory currently starts its own dynamic import when called concurrently.

## Changes

- cache one retryable in-flight dynamic-import promise per provider module
- clear rejected imports so later calls can retry
- keep imports lazy while returning fresh provider instances with independent options
- add helper-level and provider-registry concurrency coverage
- restrict coverage discovery to TypeScript source files
- document the provider and test directory invariants

## Validation

- `pnpm test` — lint, build, both TypeScript checks, coverage, and 249 tests passed
- focused concurrency tests with shuffled order, seeds 1–3