### PR TITLE
fix: avoid wildcarding exact archive URLs

### DIFF
--- a/src/utils/_utils.ts
+++ b/src/utils/_utils.ts
@@ -135,7 +135,7 @@ export function waybackTimestampToISO(timestamp: string): string {
 /**
  * Normalizes a domain string for search queries
  * @param domain The domain or URL to normalize
- * @param appendWildcard Whether to append a wildcard for prefix matching
+ * @param appendWildcard Whether a bare host should use prefix matching
  * @returns Normalized domain string
  */
 export function normalizeDomain(domain: string, appendWildcard = true): string {
@@ -143,11 +143,14 @@ export function normalizeDomain(domain: string, appendWildcard = true): string {
   const normalizedDomain = hasProtocol(domain) ? withoutProtocol(domain) : domain;
 
   // Create URL pattern for search if requested
-  if (domain.includes("*")) {
+  if (!appendWildcard || domain.includes("*")) {
     return normalizedDomain;
   }
 
-  return appendWildcard ? withTrailingSlash(normalizedDomain) + "*" : normalizedDomain;
+  const suffixStart = normalizedDomain.search(/[/?#]/);
+  const isBareHost = suffixStart === -1 || /^\/+$/u.test(normalizedDomain.slice(suffixStart));
+
+  return isBareHost ? withTrailingSlash(normalizedDomain) + "*" : normalizedDomain;
 }
 
 /**

--- a/test/archive-it.test.ts
+++ b/test/archive-it.test.ts
@@ -108,7 +108,7 @@ describe("Archive-It", () => {
       "/4399/timemap/cdx",
       expect.objectContaining({
         params: expect.objectContaining({
-          url: "example.com/page/*",
+          url: "example.com/page",
           collapse: "timestamp:10",
           filter: "statuscode:200",
           from: "2020",

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { mapCdxRows, processInParallel, waybackTimestampToISO } from "../src/utils";
+import {
+  mapCdxRows,
+  normalizeDomain,
+  processInParallel,
+  waybackTimestampToISO,
+} from "../src/utils";
 
 describe("processInParallel", () => {
   it("preserves input order regardless of completion order", async () => {
@@ -41,6 +46,21 @@ describe("processInParallel", () => {
     });
 
     expect(result).toEqual([2, 4]);
+  });
+});
+
+describe("normalizeDomain", () => {
+  it("keeps a bare host as a prefix search", () => {
+    expect(normalizeDomain("https://example.com/")).toBe("example.com/*");
+  });
+
+  it("keeps paths and queries exact", () => {
+    expect(normalizeDomain("https://example.com/page")).toBe("example.com/page");
+    expect(normalizeDomain("https://example.com/?q=1")).toBe("example.com/?q=1");
+  });
+
+  it("keeps a caller-supplied wildcard", () => {
+    expect(normalizeDomain("https://example.com/pages/*")).toBe("example.com/pages/*");
   });
 });
 


### PR DESCRIPTION
Exact archive URLs should not be rewritten as prefixes. `normalizeDomain()` now reserves `/*` for bare hosts; paths and queries stay exact, and explicit wildcards stay untouched. The live `CC-MAIN-2024-30` pair is pretty blunt: one capture exact, none with `/*`. Closes #52
