### PR TITLE
refactor: make shared Ox checks real

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -16,7 +16,7 @@ jobs:
       - run: npm i -fg corepack && corepack enable
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: "pnpm"
       - run: pnpm install
       - run: pnpm lint:fix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - run: npm i -fg corepack && corepack enable
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: "pnpm"
       - run: pnpm install
       - run: pnpm lint

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://unpkg.com/oxfmt/configuration_schema.json",
-  "ignorePatterns": ["dist", "coverage", ".nuxt", ".output"]
-}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://unpkg.com/oxlint/configuration_schema.json",
-  "plugins": ["unicorn", "typescript", "oxc"],
-  "rules": {},
-  "ignorePatterns": ["dist", "coverage", ".nuxt", ".output"]
-}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,61 +40,61 @@ archives/
 
 ## WHERE TO LOOK
 
-| Task                      | Location                                                | Notes                                                                              |
-| ------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Add a provider            | `src/providers/` + register in `src/providers/index.ts` | Copy wayback.ts as template. Default export factory fn returning `ArchiveProvider` |
-| Provider-specific options | `src/_providers.ts`                                     | Extend `ArchiveOptions`, add to `ProviderOptions` map                              |
-| Change public API         | `src/index.ts`                                          | Barrel re-exports only. Types via `export type *`                                  |
-| Modify caching            | `src/storage.ts`                                        | Key format: `{prefix}:{providerSlug}:{domain}:{limit?}`                            |
-| Config defaults           | `src/config.ts` → `getDefaultConfig()`                  | c12 loads from `.archives`, `archives.config.ts`, `package.json`                   |
-| Response helpers          | `src/utils/_utils.ts`                                   | `createSuccessResponse`, `createErrorResponse`, `mergeOptions`                     |
-| Read an archived body     | `src/utils/_content.ts`                                 | Capture selection, `id_` playback, WARC ranges, transfer/content encodings, charset, `htmlToText` |
-| Add content to a provider | provider file → `override content()`                    | Optional on `ArchiveProvider`; a provider that cannot serve bodies says so instead |
-| Parallel processing       | `src/utils/_utils.ts` → `processInParallel`             | Concurrency + batch control                                                        |
-| CDX row mapping           | `src/utils/_utils.ts` → `mapCdxRows`                    | Wayback/CommonCrawl share CDX format                                               |
-| Test a provider           | `test/{provider}.test.ts`                               | Uses vitest, mocks with `vi.fn()`                                                  |
-| Manual testing            | `playground/server/api/snapshots/`                      | One Nuxt endpoint per provider                                                     |
-| Extend Pi extension       | `packages/pi/extensions/archives.ts` + `tsconfig.extensions.json` | Keep it distributable through `package.json` `pi.extensions` like askweb            |
-| Change what a tool does   | `src/tool-operations.ts`                                | One implementation for MCP, Pi and OMP. Never fix a tool in one surface only        |
-| Add/change an MCP tool    | `src/mcp.ts` + `test/mcp.test.ts`                       | Executor in tool-operations first, then the TypeBox schema and annotations here     |
-| Verify the shipped package | `pnpm pack` + install the tarball elsewhere            | Catches missing `files`, a wrong `exports` map and absent runtime deps             |
+| Task                       | Location                                                          | Notes                                                                                             |
+| -------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Add a provider             | `src/providers/` + register in `src/providers/index.ts`           | Copy wayback.ts as template. Default export factory fn returning `ArchiveProvider`                |
+| Provider-specific options  | `src/_providers.ts`                                               | Extend `ArchiveOptions`, add to `ProviderOptions` map                                             |
+| Change public API          | `src/index.ts`                                                    | Barrel re-exports only. Types via `export type *`                                                 |
+| Modify caching             | `src/storage.ts`                                                  | Key format: `{prefix}:{providerSlug}:{domain}:{limit?}`                                           |
+| Config defaults            | `src/config.ts` → `getDefaultConfig()`                            | c12 loads from `.archives`, `archives.config.ts`, `package.json`                                  |
+| Response helpers           | `src/utils/_utils.ts`                                             | `createSuccessResponse`, `createErrorResponse`, `mergeOptions`                                    |
+| Read an archived body      | `src/utils/_content.ts`                                           | Capture selection, `id_` playback, WARC ranges, transfer/content encodings, charset, `htmlToText` |
+| Add content to a provider  | provider file → `override content()`                              | Optional on `ArchiveProvider`; a provider that cannot serve bodies says so instead                |
+| Parallel processing        | `src/utils/_utils.ts` → `processInParallel`                       | Concurrency + batch control                                                                       |
+| CDX row mapping            | `src/utils/_utils.ts` → `mapCdxRows`                              | Wayback/CommonCrawl share CDX format                                                              |
+| Test a provider            | `test/{provider}.test.ts`                                         | Uses vitest, mocks with `vi.fn()`                                                                 |
+| Manual testing             | `playground/server/api/snapshots/`                                | One Nuxt endpoint per provider                                                                    |
+| Extend Pi extension        | `packages/pi/extensions/archives.ts` + `tsconfig.extensions.json` | Keep it distributable through `package.json` `pi.extensions` like askweb                          |
+| Change what a tool does    | `src/tool-operations.ts`                                          | One implementation for MCP, Pi and OMP. Never fix a tool in one surface only                      |
+| Add/change an MCP tool     | `src/mcp.ts` + `test/mcp.test.ts`                                 | Executor in tool-operations first, then the TypeBox schema and annotations here                   |
+| Verify the shipped package | `pnpm pack` + install the tarball elsewhere                       | Catches missing `files`, a wrong `exports` map and absent runtime deps                            |
 
 ## CODE MAP
 
-| Symbol                      | Type      | Location              | Role                                                                                        |
-| --------------------------- | --------- | --------------------- | ------------------------------------------------------------------------------------------- |
-| `createArchive`             | function  | archive.ts:56         | Core factory. Accepts provider(s) + options, returns `ArchiveInterface`.                    |
-| `UnsupportedOperationError` | class     | archive.ts:18         | Thrown by `getPages()` when every queried provider is unsupported. Carries `providers` list. |
-| `providers`                 | object    | providers/index.ts:14 | Lazy-loading factory. Each method returns `Promise<ArchiveProvider>`.                       |
-| `MementoProvider`           | class     | providers/memento.ts  | JSON TimeMap from several archives via ODU MemGator; reads exact Memento URI, then proxy fallback. |
-| `ArchiveInterface`          | interface | types.ts:127          | Public API: `snapshots()`, `getPages()`, `use()`, `useAll()`.                               |
-| `ArchiveProvider`           | interface | types.ts:117          | Provider contract: `name`, `slug?`, `snapshots()`.                                          |
-| `ArchiveResponse`           | interface | types.ts:100          | `{ success, pages, error?, unsupported?, unsupportedReason?, _meta?, fromCache? }`.         |
-| `ArchivedPage`              | interface | types.ts:61           | `{ url, timestamp, snapshot, _meta }`.                                                      |
-| `UnsupportedProviderRecord` | interface | types.ts:84           | `{ provider, reason }` row used in `_meta.unsupportedProviders`.                            |
-| `ArchivesConfig`            | interface | config.ts:8           | Config shape: `storage` + `performance` + env overrides.                                    |
-| `processInParallel`         | function  | utils/_utils.ts:16    | Generic parallel executor with concurrency + batching.                                      |
-| `createSuccessResponse`     | function  | utils/_utils.ts       | Build a normalized success `ArchiveResponse`.                                               |
-| `createErrorResponse`       | function  | utils/_utils.ts       | Build a normalized runtime-error `ArchiveResponse`.                                         |
-| `createUnsupportedResponse` | function  | utils/_utils.ts:184   | Build a response signalling the operation is outside the provider's API surface.            |
-| `configureStorage`          | function  | storage.ts:147        | **@deprecated** – use config files or `createArchive` options.                              |
-| `archives`                  | Pi tool   | packages/pi/extensions/archives.ts | Query archive snapshots through Pi; delegates to the shared executors (source first, `dist/` in an installed package).       |
-| `archives_providers`        | Pi tool   | packages/pi/extensions/archives.ts | List provider status and Perma.cc env configuration.                                        |
-| `snapshotArchives`          | function  | tool-operations.ts    | Shared executor behind the snapshot tool on every surface. Throws on bad provider/prereqs.  |
-| `listArchiveProviders`      | function  | tool-operations.ts    | Shared executor listing providers, `provider=all` membership and Perma.cc key state.        |
-| `waybackSnapshots`          | function  | tool-operations.ts    | Wayback-only lookup behind the interactive `/archive` command.                              |
-| `createMcpServer`           | function  | mcp.ts                | Unconnected MCP server exposing `archives_snapshots`, `archives_content`, `archives_providers`. |
-| `Archive.content`           | method    | archive.ts            | Reads one capture. Tries providers in order; the first body wins.                           |
-| `Archive.getContent`        | method    | archive.ts            | Throwing variant of `content()`, mirroring `getPages()`.                                    |
-| `combineContentResults`     | function  | archive.ts            | Picks the winning body and keeps the other providers' outcomes in `_meta`.                  |
-| `ArchivedContent`           | interface | types.ts              | `{ url, timestamp, snapshot, content, mime?, bytes, truncated, _meta }`.                    |
-| `ArchiveContentOptions`     | interface | types.ts              | `ArchiveOptions` + `timestamp` (capture to read) + `maxBytes` (read cap).                   |
-| `readPlaybackCapture`       | function  | utils/_content.ts     | Reads a Wayback-style `<prefix>/<stamp>id_/<url>` capture into `ArchivedContent`.            |
-| `selectCapture`             | function  | utils/_content.ts     | An exact stamp names one capture; otherwise newest at or before, else closest after, preferring a 2xx one. |
-| `preferSameUrl`             | function  | utils/_content.ts     | Keeps candidates recorded under the requested URL, and the scheme when the caller named one. |
-| `unwrapSnapshotUrl`         | function  | utils/_content.ts     | Splits a playback URL back into original URL + capture stamp.                                |
-| `htmlToText`                | function  | utils/_content.ts     | Lossy markup stripping, applied by the surfaces, never by the library response.              |
-| `contentArchives`           | function  | tool-operations.ts    | Shared executor behind the content tool on every surface.                                    |
+| Symbol                      | Type      | Location                           | Role                                                                                                                   |
+| --------------------------- | --------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `createArchive`             | function  | archive.ts:56                      | Core factory. Accepts provider(s) + options, returns `ArchiveInterface`.                                               |
+| `UnsupportedOperationError` | class     | archive.ts:18                      | Thrown by `getPages()` when every queried provider is unsupported. Carries `providers` list.                           |
+| `providers`                 | object    | providers/index.ts:14              | Lazy-loading factory. Each method returns `Promise<ArchiveProvider>`.                                                  |
+| `MementoProvider`           | class     | providers/memento.ts               | JSON TimeMap from several archives via ODU MemGator; reads exact Memento URI, then proxy fallback.                     |
+| `ArchiveInterface`          | interface | types.ts:127                       | Public API: `snapshots()`, `getPages()`, `use()`, `useAll()`.                                                          |
+| `ArchiveProvider`           | interface | types.ts:117                       | Provider contract: `name`, `slug?`, `snapshots()`.                                                                     |
+| `ArchiveResponse`           | interface | types.ts:100                       | `{ success, pages, error?, unsupported?, unsupportedReason?, _meta?, fromCache? }`.                                    |
+| `ArchivedPage`              | interface | types.ts:61                        | `{ url, timestamp, snapshot, _meta }`.                                                                                 |
+| `UnsupportedProviderRecord` | interface | types.ts:84                        | `{ provider, reason }` row used in `_meta.unsupportedProviders`.                                                       |
+| `ArchivesConfig`            | interface | config.ts:8                        | Config shape: `storage` + `performance` + env overrides.                                                               |
+| `processInParallel`         | function  | utils/_utils.ts:16                 | Generic parallel executor with concurrency + batching.                                                                 |
+| `createSuccessResponse`     | function  | utils/_utils.ts                    | Build a normalized success `ArchiveResponse`.                                                                          |
+| `createErrorResponse`       | function  | utils/_utils.ts                    | Build a normalized runtime-error `ArchiveResponse`.                                                                    |
+| `createUnsupportedResponse` | function  | utils/_utils.ts:184                | Build a response signalling the operation is outside the provider's API surface.                                       |
+| `configureStorage`          | function  | storage.ts:147                     | **@deprecated** - use config files or `createArchive` options.                                                         |
+| `archives`                  | Pi tool   | packages/pi/extensions/archives.ts | Query archive snapshots through Pi; delegates to the shared executors (source first, `dist/` in an installed package). |
+| `archives_providers`        | Pi tool   | packages/pi/extensions/archives.ts | List provider status and Perma.cc env configuration.                                                                   |
+| `snapshotArchives`          | function  | tool-operations.ts                 | Shared executor behind the snapshot tool on every surface. Throws on bad provider/prereqs.                             |
+| `listArchiveProviders`      | function  | tool-operations.ts                 | Shared executor listing providers, `provider=all` membership and Perma.cc key state.                                   |
+| `waybackSnapshots`          | function  | tool-operations.ts                 | Wayback-only lookup behind the interactive `/archive` command.                                                         |
+| `createMcpServer`           | function  | mcp.ts                             | Unconnected MCP server exposing `archives_snapshots`, `archives_content`, `archives_providers`.                        |
+| `Archive.content`           | method    | archive.ts                         | Reads one capture. Tries providers in order; the first body wins.                                                      |
+| `Archive.getContent`        | method    | archive.ts                         | Throwing variant of `content()`, mirroring `getPages()`.                                                               |
+| `combineContentResults`     | function  | archive.ts                         | Picks the winning body and keeps the other providers' outcomes in `_meta`.                                             |
+| `ArchivedContent`           | interface | types.ts                           | `{ url, timestamp, snapshot, content, mime?, bytes, truncated, _meta }`.                                               |
+| `ArchiveContentOptions`     | interface | types.ts                           | `ArchiveOptions` + `timestamp` (capture to read) + `maxBytes` (read cap).                                              |
+| `readPlaybackCapture`       | function  | utils/_content.ts                  | Reads a Wayback-style `<prefix>/<stamp>id_/<url>` capture into `ArchivedContent`.                                      |
+| `selectCapture`             | function  | utils/_content.ts                  | An exact stamp names one capture; otherwise newest at or before, else closest after, preferring a 2xx one.             |
+| `preferSameUrl`             | function  | utils/_content.ts                  | Keeps candidates recorded under the requested URL, and the scheme when the caller named one.                           |
+| `unwrapSnapshotUrl`         | function  | utils/_content.ts                  | Splits a playback URL back into original URL + capture stamp.                                                          |
+| `htmlToText`                | function  | utils/_content.ts                  | Lossy markup stripping, applied by the surfaces, never by the library response.                                        |
+| `contentArchives`           | function  | tool-operations.ts                 | Shared executor behind the content tool on every surface.                                                              |
 
 ## CONVENTIONS
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,8 +140,8 @@ pnpm install          # install deps
 pnpm dev              # vitest watch mode
 pnpm test             # lint + type-check + vitest with coverage
 pnpm test:types       # build + tsc over lib and both extension surfaces
-pnpm lint             # build + type-aware oxlint + oxfmt check
-pnpm lint:fix         # build + oxlint fixes + oxfmt write
+pnpm lint             # build + Nuxt types + type-aware oxlint + oxfmt check
+pnpm lint:fix         # build + Nuxt types + oxlint fixes + oxfmt write
 pnpm build            # obuild (build.config.ts) → dist/
 node dist/cli.mjs mcp # run the MCP server over stdio (bin: archives mcp)
 pnpm release          # test + changelogen + publish

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ archives/
 - **Unsupported operations are first-class**: when an operation is outside a provider's API surface (e.g. WebCite has no list-by-domain endpoint), return `createUnsupportedResponse(reason, slug)`, not a fake page or a fake error. `combineResults` propagates these into `_meta.unsupportedProviders`. `getPages()` throws `UnsupportedOperationError` (with `.providers`) when the whole call is unsupported, so callers can distinguish structural mismatches from runtime failures.
 - **Timestamp format**: providers convert native timestamps to ISO 8601. Raw format preserved in `_meta`.
 - **Option merging**: three-level cascade: config defaults → init options → request options. Via `mergeOptions()`.
-- **Linting**: `oxlint` only; ESLint was removed intentionally.
+- **Quality config**: `oxlint` and `oxfmt` spread the shared `@agntn/ox` policies. Linting is type-aware; ESLint was removed intentionally.
 - **Build**: `obuild` reads `build.config.ts` → `dist/`. Four inputs in **one** bundle entry so the entrypoint, the CLI, the MCP server and the executors share chunks instead of each carrying a private copy of the provider factory.
 - **One executor per operation**: MCP, Pi and OMP all call `src/tool-operations.ts`. A surface owns only its schema, its call rendering and its result envelope. Schema metadata (`PROVIDER_HINT`, limits) is restated per surface because parameters are declared before the executors can be loaded — the extension tests guard it against drift.
 - **OMP loader imports stay literal**: `existsSync(src)` chooses between `import("../../../src/tool-operations.ts")` and `import("../../../dist/tool-operations.mjs")`. Never `import(url.href)`. `tsc` resolves that dist specifier, so `test:types` builds before it type-checks.
@@ -140,8 +140,8 @@ pnpm install          # install deps
 pnpm dev              # vitest watch mode
 pnpm test             # lint + type-check + vitest with coverage
 pnpm test:types       # build + tsc over lib and both extension surfaces
-pnpm lint             # oxlint
-pnpm lint:fix         # oxlint --fix
+pnpm lint             # build + type-aware oxlint + oxfmt check
+pnpm lint:fix         # build + oxlint fixes + oxfmt write
 pnpm build            # obuild (build.config.ts) → dist/
 node dist/cli.mjs mcp # run the MCP server over stdio (bin: archives mcp)
 pnpm release          # test + changelogen + publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 - **types:** Replace as any/as unknown as with proper types ([02c19af](https://github.com/agntn/archives/commit/02c19af))
 - Surface unsupported provider operations end-to-end ([968f191](https://github.com/agntn/archives/commit/968f191))
 - Use classes ([#18](https://github.com/agntn/archives/pull/18))
-- ⚠️  Rename package to @agntn/archives ([#24](https://github.com/agntn/archives/pull/24))
+- ⚠️ Rename package to @agntn/archives ([#24](https://github.com/agntn/archives/pull/24))
 
 ### 🏡 Chore
 
@@ -95,7 +95,7 @@
 
 #### ⚠️ Breaking Changes
 
-- ⚠️  Rename package to @agntn/archives ([#24](https://github.com/agntn/archives/pull/24))
+- ⚠️ Rename package to @agntn/archives ([#24](https://github.com/agntn/archives/pull/24))
 
 ### ❤️ Contributors
 

--- a/README.md
+++ b/README.md
@@ -173,17 +173,17 @@ response._meta?.unsupportedProviders; // [{ provider: "webcite", reason: "..." }
 
 ## Providers
 
-| Provider        | Factory                    | `content()` | Notes                                                                                              |
-| --------------- | -------------------------- | ----------- | -------------------------------------------------------------------------------------------------- |
-| Wayback Machine | `providers.wayback()`      | yes         | web.archive.org CDX API; captures replayed under `id_`                                             |
-| Archive-It      | `providers.archiveIt()`    | yes         | Requires a numeric `collection`; collection-specific CDX/C API                                     |
-| Conifer         | `providers.conifer()`      | no          | Requires `user` and `collection`; searches an existing public collection                           |
-| Archive.today   | `providers.archiveToday()` | yes         | archive.ph via Memento timemap; bodies are the rendered wrapper page, not the original bytes       |
+| Provider        | Factory                    | `content()` | Notes                                                                                                       |
+| --------------- | -------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------- |
+| Wayback Machine | `providers.wayback()`      | yes         | web.archive.org CDX API; captures replayed under `id_`                                                      |
+| Archive-It      | `providers.archiveIt()`    | yes         | Requires a numeric `collection`; collection-specific CDX/C API                                              |
+| Conifer         | `providers.conifer()`      | no          | Requires `user` and `collection`; searches an existing public collection                                    |
+| Archive.today   | `providers.archiveToday()` | yes         | archive.ph via Memento timemap; bodies are the rendered wrapper page, not the original bytes                |
 | Memento         | `providers.memento()`      | yes         | Public ODU MemGator JSON TimeMap; queries several archives; excluded from `all` to avoid duplicate requests |
-| Common Crawl    | `providers.commoncrawl()`  | yes         | Defaults to latest collection; bodies read from the WARC byte range                                |
-| Perma.cc        | `providers.permacc()`      | no          | Requires `apiKey`; exact URL lookup only; API returns metadata only                                |
-| WebCite         | `providers.webcite()`      | no          | No list-by-domain API; `snapshots()` returns unsupported. New archives no longer accepted (~2019). |
-| All             | `providers.all()`          | n/a         | Wayback, Archive.today, Common Crawl, and WebCite                                                  |
+| Common Crawl    | `providers.commoncrawl()`  | yes         | Defaults to latest collection; bodies read from the WARC byte range                                         |
+| Perma.cc        | `providers.permacc()`      | no          | Requires `apiKey`; exact URL lookup only; API returns metadata only                                         |
+| WebCite         | `providers.webcite()`      | no          | No list-by-domain API; `snapshots()` returns unsupported. New archives no longer accepted (~2019).          |
+| All             | `providers.all()`          | n/a         | Wayback, Archive.today, Common Crawl, and WebCite                                                           |
 
 A provider that cannot serve bodies answers `content()` as unsupported with the reason, exactly as it does for a listing it has no endpoint for.
 

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "oxfmt";
+import oxfmt from "@agntn/ox/oxfmt";
+
+export default defineConfig({
+  ...oxfmt,
+  ignorePatterns: ["dist", "coverage", ".nuxt", ".output"],
+});

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1,0 +1,69 @@
+import { defineConfig } from "oxlint";
+import oxlint from "@agntn/ox/oxlint";
+
+export default defineConfig({
+  ...oxlint,
+  rules: {
+    ...oxlint.rules,
+    "typescript/prefer-readonly-parameter-types": [
+      "error",
+      {
+        allow: [
+          // Public/provider DTOs stay mutable for compatibility; call sites use
+          // shallow readonly views instead of changing the exported shapes.
+          {
+            from: "file",
+            name: [
+              "ArchiveContentOptions",
+              "ArchiveContentResponse",
+              "ArchiveInterface",
+              "ArchiveItOptions",
+              "ArchiveOptions",
+              "ArchiveProvider",
+              "ArchiveResponse",
+              "ArchiveTodayOptions",
+              "ArchivedContent",
+              "ArchivedPage",
+              "ArchivesConfig",
+              "CommonCrawlOptions",
+              "ConiferOptions",
+              "MementoOptions",
+              "PermaccOptions",
+              "ProviderInput",
+              "ProviderReference",
+              "ResolveConfigOptions",
+              "ToolResult",
+              "WaybackOptions",
+              "WebCiteOptions",
+            ],
+          },
+          // These internal accumulators are intentionally mutated while folding results.
+          { from: "file", name: ["ContentMergeState", "ListingMergeState"] },
+          // Platform and dependency contracts are not owned by this package.
+          {
+            from: "lib",
+            name: ["AbortSignal", "ReadableStream", "ReadonlyMap", "RegExp", "Uint8Array", "URL"],
+          },
+          {
+            from: "package",
+            name: ["FetchOptions", "FetchResponse"],
+            package: "ofetch",
+          },
+          { from: "package", name: "Driver", package: "unstorage" },
+          {
+            from: "package",
+            name: ["ExtensionAPI", "ExtensionContext", "ToolDefinition"],
+            package: "@earendil-works/pi-coding-agent",
+          },
+          {
+            from: "package",
+            name: ["ExtensionAPI", "ExtensionContext", "ToolDefinition"],
+            package: "@oh-my-pi/pi-coding-agent",
+          },
+        ],
+        ignoreInferredTypes: true,
+      },
+    ],
+  },
+  ignorePatterns: ["dist", "coverage", ".nuxt", ".output"],
+});

--- a/package.json
+++ b/package.json
@@ -64,9 +64,9 @@
   },
   "scripts": {
     "dev": "vitest dev",
-    "lint": "oxlint .",
-    "lint:fix": "oxlint . --fix",
-    "fmt": "oxlint . --fix && oxfmt .",
+    "lint": "pnpm build && oxlint . && oxfmt --check .",
+    "lint:fix": "pnpm build && oxlint . --fix && oxfmt .",
+    "fmt": "pnpm build && oxlint . --fix && oxfmt .",
     "fmt:check": "oxfmt --check .",
     "test": "pnpm lint && pnpm test:types && vitest run --coverage",
     "test:types": "pnpm build && tsc --noEmit --skipLibCheck && tsc --noEmit --skipLibCheck -p tsconfig.extensions.json",

--- a/package.json
+++ b/package.json
@@ -64,9 +64,10 @@
   },
   "scripts": {
     "dev": "vitest dev",
-    "lint": "pnpm build && oxlint . && oxfmt --check .",
-    "lint:fix": "pnpm build && oxlint . --fix && oxfmt .",
-    "fmt": "pnpm build && oxlint . --fix && oxfmt .",
+    "quality:prepare": "pnpm build && pnpm --dir playground exec nuxt prepare",
+    "lint": "pnpm quality:prepare && oxlint . && oxfmt --check .",
+    "lint:fix": "pnpm quality:prepare && oxlint . --fix && oxfmt .",
+    "fmt": "pnpm quality:prepare && oxlint . --fix && oxfmt .",
     "fmt:check": "oxfmt --check .",
     "test": "pnpm lint && pnpm test:types && vitest run --coverage",
     "test:types": "pnpm build && tsc --noEmit --skipLibCheck && tsc --noEmit --skipLibCheck -p tsconfig.extensions.json",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "publishConfig": {
-    "access": "public"
-  },
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
@@ -61,6 +58,9 @@
       "import": "./dist/tool-operations.mjs",
       "default": "./dist/tool-operations.mjs"
     }
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "dev": "vitest dev",
@@ -85,6 +85,7 @@
     "unstorage": "1.17.5"
   },
   "devDependencies": {
+    "@agntn/ox": "^0.1.0",
     "@earendil-works/pi-coding-agent": "0.84.1",
     "@earendil-works/pi-tui": "0.84.1",
     "@oh-my-pi/omptype": "17.3.0",
@@ -93,8 +94,9 @@
     "@vitest/coverage-v8": "4.1.10",
     "changelogen": "0.6.2",
     "obuild": "0.4.38",
-    "oxfmt": "0.62.0",
-    "oxlint": "1.77.0",
+    "oxfmt": "0.65.0",
+    "oxlint": "1.80.0",
+    "oxlint-tsgolint": "7.0.2001",
     "typescript": "7.0.2",
     "vitest": "4.1.10"
   },

--- a/packages/omp/extensions/archives.ts
+++ b/packages/omp/extensions/archives.ts
@@ -7,11 +7,20 @@ import type * as ArchivesTools from "@agntn/archives/tool-operations";
 type ContentDetails = ArchivesTools.ContentDetails;
 type ProvidersDetails = ArchivesTools.ProvidersDetails;
 type SnapshotDetails = ArchivesTools.SnapshotDetails;
+interface WaybackResponseSummary {
+  readonly success: boolean;
+  readonly pages: readonly unknown[];
+}
+
+interface CommandNotice {
+  message: string;
+  level: "error" | "warning";
+}
 
 const sourceModulePath = fileURLToPath(new URL("../../../src/tool-operations.ts", import.meta.url));
 let toolOperationsPromise: Promise<typeof ArchivesTools> | undefined;
 
-/**
+/*
  * Loads the tool executors shared with the MCP server and the Pi extension.
  *
  * Both specifiers stay literal: OMP rewrites bare dependencies only for imports
@@ -67,14 +76,14 @@ const MAX_TTL = 30 * 24 * 60 * 60 * 1000;
 const MAX_RETRIES = 10;
 const MAX_TIMEOUT = 5 * 60 * 1000;
 // oxlint-disable-next-line no-control-regex -- Terminal control bytes are precisely what this boundary removes.
-const UNSAFE_TERMINAL_CONTROLS = /[\u0000-\u0008\u000b-\u001f\u007f-\u009f]/gu;
+const UNSAFE_TERMINAL_CONTROLS = /[\u0000-\u0008\u000B-\u001F\u007F-\u009F]/gu;
 
-/** Local copy: the TUI renders call previews before the executors can be loaded. */
+/* Local copy: the TUI renders call previews before the executors can be loaded. */
 function sanitizeTerminalText(text: string): string {
   return text.replace(UNSAFE_TERMINAL_CONTROLS, "");
 }
 
-/**
+/*
  * One-line form for anything the UI prints.
  *
  * Stripping control bytes is not enough: a bare newline in a provider value or a
@@ -82,17 +91,35 @@ function sanitizeTerminalText(text: string): string {
  * look like a real one.
  */
 function sanitizeLine(text: string): string {
-  return sanitizeTerminalText(text).replace(/[\n\r\t]+/g, " ");
+  return sanitizeTerminalText(text).replaceAll(/[\n\r\t]+/g, " ");
 }
 
-/**
+function archiveCommandNotice(
+  response: WaybackResponseSummary,
+  target: string,
+  failureMessage: string,
+): CommandNotice | undefined {
+  if (!response.success) {
+    return { message: `archives failed: ${failureMessage}`, level: "error" };
+  }
+  if (response.pages.length === 0) {
+    return {
+      message: `No archived snapshots for "${sanitizeLine(target)}" via Wayback.`,
+      level: "warning",
+    };
+  }
+  return undefined;
+}
+
+/*
  * Builds the tool parameter schemas from the TypeBox build OMP injects.
  *
  * Importing `@oh-my-pi/omptype` here instead loads a second copy of the schema
  * library at module load, before the host has a single tool call to validate,
  * and that import alone was most of what this extension cost at startup.
  */
-function buildParameterSchemas({ Type }: ExtensionAPI["typebox"]) {
+function buildParameterSchemas(pi: ExtensionAPI) {
+  const { Type } = pi.typebox;
   const snapshotParameters = Type.Object({
     target: Type.String({
       description: "Domain or URL to search for archived snapshots.",
@@ -281,9 +308,7 @@ type EmptyParams = Static<ParameterSchemas["emptyParameters"]>;
 
 export default function archivesOmpExtension(pi: ExtensionAPI) {
   const { Text } = pi.pi;
-  const { contentParameters, emptyParameters, snapshotParameters } = buildParameterSchemas(
-    pi.typebox,
-  );
+  const { contentParameters, emptyParameters, snapshotParameters } = buildParameterSchemas(pi);
   pi.setLabel("Archives");
   pi.registerTool<typeof snapshotParameters, SnapshotDetails>({
     name: "archives",
@@ -358,16 +383,9 @@ export default function archivesOmpExtension(pi: ExtensionAPI) {
       }
       const { formatPage, responseFailureMessage } = tools;
 
-      if (!response.success) {
-        ctx.ui.notify(`archives failed: ${responseFailureMessage(response)}`, "error");
-        return;
-      }
-
-      if (response.pages.length === 0) {
-        ctx.ui.notify(
-          `No archived snapshots for "${sanitizeLine(trimmed)}" via Wayback.`,
-          "warning",
-        );
+      const notice = archiveCommandNotice(response, trimmed, responseFailureMessage(response));
+      if (notice) {
+        ctx.ui.notify(notice.message, notice.level);
         return;
       }
 
@@ -398,9 +416,11 @@ export default function archivesOmpExtension(pi: ExtensionAPI) {
   });
 }
 
-function renderSnapshotCall(params: SnapshotParams, theme: RenderTheme): string {
-  const parts = [theme.fg("toolTitle", theme.bold("archives"))];
-  parts.push(theme.fg("dim", truncateSingleLine(sanitizeTerminalText(params.target), 120)));
+function renderSnapshotCall(params: SnapshotParams, theme: Readonly<RenderTheme>): string {
+  const parts = [
+    theme.fg("toolTitle", theme.bold("archives")),
+    theme.fg("dim", truncateSingleLine(sanitizeTerminalText(params.target), 120)),
+  ];
   if (params.provider) parts.push(theme.fg("muted", `provider=${sanitizeLine(params.provider)}`));
   if (params.limit !== undefined) parts.push(theme.fg("muted", `limit=${params.limit}`));
   if (params.from) parts.push(theme.fg("muted", `from=${sanitizeLine(params.from)}`));
@@ -411,9 +431,11 @@ function renderSnapshotCall(params: SnapshotParams, theme: RenderTheme): string 
   return parts.join(" ");
 }
 
-function renderContentCall(params: ContentParams, theme: RenderTheme): string {
-  const parts = [theme.fg("toolTitle", theme.bold("archives_content"))];
-  parts.push(theme.fg("dim", truncateSingleLine(sanitizeTerminalText(params.target), 120)));
+function renderContentCall(params: ContentParams, theme: Readonly<RenderTheme>): string {
+  const parts = [
+    theme.fg("toolTitle", theme.bold("archives_content")),
+    theme.fg("dim", truncateSingleLine(sanitizeTerminalText(params.target), 120)),
+  ];
   if (params.timestamp) parts.push(theme.fg("muted", `at=${sanitizeLine(params.timestamp)}`));
   if (params.provider) parts.push(theme.fg("muted", `provider=${sanitizeLine(params.provider)}`));
   if (params.format) parts.push(theme.fg("muted", `format=${sanitizeLine(params.format)}`));
@@ -421,14 +443,14 @@ function renderContentCall(params: ContentParams, theme: RenderTheme): string {
   return parts.join(" ");
 }
 
-/** Usable when the executors themselves failed to load, so it cannot come from them. */
+/* Usable when the executors themselves failed to load, so it cannot come from them. */
 function plainErrorMessage(error: unknown): string {
   return sanitizeTerminalText(error instanceof Error ? error.message : String(error));
 }
 
-/** Local copy: the call preview renders before the executors can be loaded. */
+/* Local copy: the call preview renders before the executors can be loaded. */
 function truncateSingleLine(text: string, maxLength: number): string {
-  const singleLine = text.replace(/\s+/g, " ").trim();
+  const singleLine = text.replaceAll(/\s+/g, " ").trim();
   return singleLine.length <= maxLength ? singleLine : `${singleLine.slice(0, maxLength - 1)}…`;
 }
 

--- a/packages/pi/extensions/archives.ts
+++ b/packages/pi/extensions/archives.ts
@@ -8,13 +8,22 @@ import type * as ArchivesTools from "@agntn/archives/tool-operations";
 type ContentDetails = ArchivesTools.ContentDetails;
 type ProvidersDetails = ArchivesTools.ProvidersDetails;
 type SnapshotDetails = ArchivesTools.SnapshotDetails;
+interface WaybackResponseSummary {
+  readonly success: boolean;
+  readonly pages: readonly unknown[];
+}
+
+interface CommandNotice {
+  message: string;
+  level: "error" | "warning";
+}
 
 const sourceModuleUrl = new URL("../../../src/tool-operations.ts", import.meta.url);
 const distributionModuleUrl = new URL("../../../dist/tool-operations.mjs", import.meta.url);
 
 let toolOperationsPromise: Promise<typeof ArchivesTools> | undefined;
 
-/**
+/*
  * Loads the tool executors shared with the MCP server and the OMP extension.
  *
  * Source comes first because a working tree is the only place it exists; an
@@ -69,14 +78,14 @@ const MAX_TTL = 30 * 24 * 60 * 60 * 1000;
 const MAX_RETRIES = 10;
 const MAX_TIMEOUT = 5 * 60 * 1000;
 // oxlint-disable-next-line no-control-regex -- Terminal control bytes are precisely what this boundary removes.
-const UNSAFE_TERMINAL_CONTROLS = /[\u0000-\u0008\u000b-\u001f\u007f-\u009f]/gu;
+const UNSAFE_TERMINAL_CONTROLS = /[\u0000-\u0008\u000B-\u001F\u007F-\u009F]/gu;
 
-/** Local copy: the TUI renders call previews before the executors can be loaded. */
+/* Local copy: the TUI renders call previews before the executors can be loaded. */
 function sanitizeTerminalText(text: string): string {
   return text.replace(UNSAFE_TERMINAL_CONTROLS, "");
 }
 
-/**
+/*
  * One-line form for anything the UI prints.
  *
  * Stripping control bytes is not enough: a bare newline in a provider value or a
@@ -84,7 +93,24 @@ function sanitizeTerminalText(text: string): string {
  * look like a real one.
  */
 function sanitizeLine(text: string): string {
-  return sanitizeTerminalText(text).replace(/[\n\r\t]+/g, " ");
+  return sanitizeTerminalText(text).replaceAll(/[\n\r\t]+/g, " ");
+}
+
+function archiveCommandNotice(
+  response: WaybackResponseSummary,
+  target: string,
+  failureMessage: string,
+): CommandNotice | undefined {
+  if (!response.success) {
+    return { message: `archives failed: ${failureMessage}`, level: "error" };
+  }
+  if (response.pages.length === 0) {
+    return {
+      message: `No archived snapshots for "${sanitizeLine(target)}" via Wayback.`,
+      level: "warning",
+    };
+  }
+  return undefined;
 }
 
 // Integers, not plain numbers: a fractional limit clears validation and reaches
@@ -365,16 +391,9 @@ export default function archivesExtension(pi: ExtensionAPI) {
       }
       const { formatPage, responseFailureMessage } = tools;
 
-      if (!response.success) {
-        ctx.ui.notify(`archives failed: ${responseFailureMessage(response)}`, "error");
-        return;
-      }
-
-      if (response.pages.length === 0) {
-        ctx.ui.notify(
-          `No archived snapshots for "${sanitizeLine(trimmed)}" via Wayback.`,
-          "warning",
-        );
+      const notice = archiveCommandNotice(response, trimmed, responseFailureMessage(response));
+      if (notice) {
+        ctx.ui.notify(notice.message, notice.level);
         return;
       }
 
@@ -405,9 +424,11 @@ export default function archivesExtension(pi: ExtensionAPI) {
   });
 }
 
-function renderSnapshotCall(params: SnapshotParams, theme: RenderTheme): string {
-  const parts = [theme.fg("toolTitle", theme.bold("archives"))];
-  parts.push(theme.fg("dim", truncateSingleLine(sanitizeTerminalText(params.target), 120)));
+function renderSnapshotCall(params: SnapshotParams, theme: Readonly<RenderTheme>): string {
+  const parts = [
+    theme.fg("toolTitle", theme.bold("archives")),
+    theme.fg("dim", truncateSingleLine(sanitizeTerminalText(params.target), 120)),
+  ];
   if (params.provider) parts.push(theme.fg("muted", `provider=${sanitizeLine(params.provider)}`));
   if (params.limit !== undefined) parts.push(theme.fg("muted", `limit=${params.limit}`));
   if (params.from) parts.push(theme.fg("muted", `from=${sanitizeLine(params.from)}`));
@@ -418,9 +439,11 @@ function renderSnapshotCall(params: SnapshotParams, theme: RenderTheme): string 
   return parts.join(" ");
 }
 
-function renderContentCall(params: ContentParams, theme: RenderTheme): string {
-  const parts = [theme.fg("toolTitle", theme.bold("archives_content"))];
-  parts.push(theme.fg("dim", truncateSingleLine(sanitizeTerminalText(params.target), 120)));
+function renderContentCall(params: ContentParams, theme: Readonly<RenderTheme>): string {
+  const parts = [
+    theme.fg("toolTitle", theme.bold("archives_content")),
+    theme.fg("dim", truncateSingleLine(sanitizeTerminalText(params.target), 120)),
+  ];
   if (params.timestamp) parts.push(theme.fg("muted", `at=${sanitizeLine(params.timestamp)}`));
   if (params.provider) parts.push(theme.fg("muted", `provider=${sanitizeLine(params.provider)}`));
   if (params.format) parts.push(theme.fg("muted", `format=${sanitizeLine(params.format)}`));
@@ -428,14 +451,14 @@ function renderContentCall(params: ContentParams, theme: RenderTheme): string {
   return parts.join(" ");
 }
 
-/** Usable when the executors themselves failed to load, so it cannot come from them. */
+/* Usable when the executors themselves failed to load, so it cannot come from them. */
 function plainErrorMessage(error: unknown): string {
   return sanitizeTerminalText(error instanceof Error ? error.message : String(error));
 }
 
-/** Local copy: the call preview renders before the executors can be loaded. */
+/* Local copy: the call preview renders before the executors can be loaded. */
 function truncateSingleLine(text: string, maxLength: number): string {
-  const singleLine = text.replace(/\s+/g, " ").trim();
+  const singleLine = text.replaceAll(/\s+/g, " ").trim();
   return singleLine.length <= maxLength ? singleLine : `${singleLine.slice(0, maxLength - 1)}…`;
 }
 

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,3 +1,5 @@
+import { defineNuxtConfig } from "nuxt/config";
+
 export default defineNuxtConfig({
   compatibilityDate: "2025-04-20",
 

--- a/playground/server/api/snapshots/permacc.ts
+++ b/playground/server/api/snapshots/permacc.ts
@@ -1,7 +1,14 @@
+import { defineEventHandler } from "h3";
+import type { NitroRuntimeConfig } from "nitropack";
+import { useRuntimeConfig } from "nitropack/runtime";
 import { createArchive, providers } from "@agntn/archives";
 
+interface RuntimeConfig extends NitroRuntimeConfig {
+  permacc: { apiKey: string };
+}
+
 export default defineEventHandler(async (event) => {
-  const config = useRuntimeConfig(event);
+  const config = useRuntimeConfig<RuntimeConfig>(event);
 
   const archive = createArchive(
     providers.permacc({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
         specifier: 1.17.5
         version: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
     devDependencies:
+      '@agntn/ox':
+        specifier: ^0.1.0
+        version: 0.1.0(oxfmt@0.65.0)(oxlint-tsgolint@7.0.2001)(oxlint@1.80.0(oxlint-tsgolint@7.0.2001))
       '@earendil-works/pi-coding-agent':
         specifier: 0.84.1
         version: 0.84.1(@modelcontextprotocol/sdk@1.30.0)(ws@8.21.3)(zod@4.4.3)
@@ -61,11 +64,14 @@ importers:
         specifier: 0.4.38
         version: 0.4.38(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magicast@0.5.4)(typescript@7.0.2)
       oxfmt:
-        specifier: 0.62.0
-        version: 0.62.0
+        specifier: 0.65.0
+        version: 0.65.0
       oxlint:
-        specifier: 1.77.0
-        version: 1.77.0
+        specifier: 1.80.0
+        version: 1.80.0(oxlint-tsgolint@7.0.2001)
+      oxlint-tsgolint:
+        specifier: 7.0.2001
+        version: 7.0.2001
       typescript:
         specifier: 7.0.2
         version: 7.0.2
@@ -80,9 +86,17 @@ importers:
         version: link:..
       nuxt:
         specifier: ^4.5.2
-        version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(oxlint@1.77.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(terser@5.49.2)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
+        version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(oxlint@1.80.0(oxlint-tsgolint@7.0.2001))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(terser@5.49.2)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
 
 packages:
+
+  '@agntn/ox@0.1.0':
+    resolution: {integrity: sha512-bYyCMczypvi/bxDgK1gOFhOnGFAqTNnTTWl+yIocaP68wsfGtwZwxN9Rld1bMcLXRVlO9PJCl7EASqToz8dOVw==}
+    engines: {node: '>=24'}
+    peerDependencies:
+      oxfmt: '>=0.63.0'
+      oxlint: '>=1.78.0'
+      oxlint-tsgolint: '>=7.0.2001'
 
   '@anthropic-ai/sdk@0.91.1':
     resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
@@ -1171,230 +1185,260 @@ packages:
   '@oxc-project/types@0.143.0':
     resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
 
-  '@oxfmt/binding-android-arm-eabi@0.62.0':
-    resolution: {integrity: sha512-pdsv0C4gPjJ8H1+sd8u0BDx+yLACTL+rgeMIOL1ln4ihSnhw8CWXtYWgvcSkyTfgGBIzFKab+d8rx9Xl4en/Kw==}
+  '@oxfmt/binding-android-arm-eabi@0.65.0':
+    resolution: {integrity: sha512-M10Gs1SSpTNI6ahGx3M/OlIdUF4hkaP6OgUb+MS79t/Pgflk3r1nW5gPFqsZGUAXg0H1AfANT9AvLdBSTIhZKg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxfmt/binding-android-arm64@0.62.0':
-    resolution: {integrity: sha512-WC3YQ7uS/KtDrjmqwBviwFKe9qeoi+eXx8aX1z/ffG23Md75myjrJaQqTuJvdOLPoa4EYTjDWH0dHXfwulCVog==}
+  '@oxfmt/binding-android-arm64@0.65.0':
+    resolution: {integrity: sha512-6DXH5sftNlaHpWJG50hFMF+Qxtq5D2TmahvcDPxWNcGIf8qrC9Y0YgHYcYZ2hlWzaccKXh/f3GcssH8vtkl4JA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxfmt/binding-darwin-arm64@0.62.0':
-    resolution: {integrity: sha512-GM8Yf3LjjaR1I8PD0SfeoIlwhsh9GvSF+cQ8sf624Yxnjsyumn95aFzYfKJVefblfDIiOAnZ7QVm2sa21Er/0Q==}
+  '@oxfmt/binding-darwin-arm64@0.65.0':
+    resolution: {integrity: sha512-K9m7lr53pcOLETNsC88sWes/GWHUGjZyHx95UhYcSXy0r30haLdeXlSufSenEAtoLaW753WN8/l4M7GYcRt6cg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxfmt/binding-darwin-x64@0.62.0':
-    resolution: {integrity: sha512-d5THp7F8bCxLqNogEXDORRsQD6dosf3EyFtnXfBer6v+8tGdcWIjoDX9WaXrrF/26zOmL8qHpPTKCEvpBDmZkQ==}
+  '@oxfmt/binding-darwin-x64@0.65.0':
+    resolution: {integrity: sha512-sTNwIx1gre3MyiHOPLu7IGW4UyMScYL4DTmJT01p4vzB0En+OJUQz6KuH8t0PpsClRSaMuY3b0QmtoPItfO8Lg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxfmt/binding-freebsd-x64@0.62.0':
-    resolution: {integrity: sha512-1DnrtXGZooOZ0fHgAXZUaDQzBVh1CM2MNW4oBXyQ2aWKvCHjyljvT9fgBkOM0fEOb96X5eqtcfJ0YUVt9jj66g==}
+  '@oxfmt/binding-freebsd-x64@0.65.0':
+    resolution: {integrity: sha512-lYZMVIiIpnjGu5hJb2jxA8NYQ/e0OTGuaiAf4dqlGPNnPmUTu23FZRMltmjro/KkQm1uE4NT4n5yJ2zWmKcpfA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.62.0':
-    resolution: {integrity: sha512-4pQDHOYRH+Huqe0StIaWyvk2CVl/aTaqSrbZpA3/pLS2xH24ME7lBgYprhQF2fRkHBzhGGGKliwxFsDdHwx59g==}
+  '@oxfmt/binding-linux-arm-gnueabihf@0.65.0':
+    resolution: {integrity: sha512-gIdXFAt/bURnjxuoedDEWdZ0PEWEmdDcm8qdpoFYYvW3QMk/5D4vUaH4mlMeRpeTdST4izUgHVO6RawQ4QulJw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.62.0':
-    resolution: {integrity: sha512-X0jAaZJFMCVKhB6YyWVTQ/wN2DLsBcZKSMqTS76bF6riT+XZdtg2FPEdjDvdVbunO9cG+tWiVaEs4Zs38lxYog==}
+  '@oxfmt/binding-linux-arm-musleabihf@0.65.0':
+    resolution: {integrity: sha512-jJVyADto7gA2AaX5qAjAexrxx9PJQaKWOe8PICE7yKMbjBRyOHcmj9TtVJ+MZYDUQ3hodU0AcoTj0jFQ1W4C6Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm64-gnu@0.62.0':
-    resolution: {integrity: sha512-682Z8T5s8T5ATArYtsejKvbIfd8LEAXyyDkKkoZVq8HND7Vx8TYLlrDjDSeYfodMeVwHOgkj13lJYR8cj6vUSg==}
+  '@oxfmt/binding-linux-arm64-gnu@0.65.0':
+    resolution: {integrity: sha512-p3RFkB+u7u+8up99b/NEcI1hdpLDiGgJYNwDorB60n7eH+eKposAKuMBxx+NqB3b+sJP4CZmYDh9G7X62tUsKg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm64-musl@0.62.0':
-    resolution: {integrity: sha512-lk25fAl7KWaLWVJcW0CHEXB7QlQZtx5eDkjpaGMK0hzXTjUe0Wmlu8IKuFHoviSOcEJedRTs4VE/506VqGxGew==}
+  '@oxfmt/binding-linux-arm64-musl@0.65.0':
+    resolution: {integrity: sha512-5Prb0uFzJHr+OUD/qS/TmU526wD+PaHDsm3KoRiUXbMIDpTSErjeQYkK3OQeshAvD/PuLa9WGEi9WPajjdOZJg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.62.0':
-    resolution: {integrity: sha512-SFyNqHQLwySceWNLhiSldx7wPXRAzP0L0WcW9GegP3uWrpZGJiZlQO85NbHAFPEfxR9PhZ9qSnZryEh7+v+4Gw==}
+  '@oxfmt/binding-linux-ppc64-gnu@0.65.0':
+    resolution: {integrity: sha512-S8svxTp81obnF3admN9yd+u2rOYXtyzThLGBTg1PY6TPtGcC09BaaXLQD+TBSMa7yvqhCDZ8DFri+S/yG60qCg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.62.0':
-    resolution: {integrity: sha512-KYj55C1ywJfHo6+aKDuEmUtVEdJALsC5GwayDGsI6FGz2GxFqNr/mA8nxVsNbJzm7sE5MRqTQ9ziImSzhYXysA==}
+  '@oxfmt/binding-linux-riscv64-gnu@0.65.0':
+    resolution: {integrity: sha512-WtXBr75G/h2qOHy8SiGtC1R6aS3jt4mE52v1D8AtwMXIgoOmSNP9lKvbSaTRoL0e5wsMPoi6T72QWDYPu+S+nA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
 
-  '@oxfmt/binding-linux-riscv64-musl@0.62.0':
-    resolution: {integrity: sha512-BhZDNo5GOU5nC378RhD0/XpvaEBHsH3HLgJp8YZX3A0InC7oivzA63HsRmiXFLtLSHAstEVrDf6fbC7Rs8Jh/A==}
+  '@oxfmt/binding-linux-riscv64-musl@0.65.0':
+    resolution: {integrity: sha512-YwSLVvpaz4o/nv/miiPEBJz+eJ+VmbgNIrao6RccK9ce+L5EA8wP+ZD0uFeq6wKOza6zoWv/dR0sj6lip6R3EA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
 
-  '@oxfmt/binding-linux-s390x-gnu@0.62.0':
-    resolution: {integrity: sha512-UyAFmyHkgSgUJ/wOM4p3U8AC2yAFvRH5PNBs7TnK0fObTT/XSWcdr/lAzPSWaekHaZFaMeFZyk9n93Joq3J93A==}
+  '@oxfmt/binding-linux-s390x-gnu@0.65.0':
+    resolution: {integrity: sha512-XQTPqgvyrgkKcFq+Tp2eK6JS7sqqJ+nRmy2Fav4j3I+i4dJoPJm7YwEdoeSDX9xkqj9jZ/lWfF3bXUWztIrn6A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
-  '@oxfmt/binding-linux-x64-gnu@0.62.0':
-    resolution: {integrity: sha512-1iYMP0leytWazFubD/WnINJuIrzRPuoL1aWEJdlGezEzDbTxcd29R4r8IUzP2oWeKst5V02uMJgR2NILlPlG6w==}
+  '@oxfmt/binding-linux-x64-gnu@0.65.0':
+    resolution: {integrity: sha512-cjZlx6S/VkeCNWCbwZriTnLnZeTcV3DEyeRGSw/2wwLP9viq+C0bJ4bC1k/ZLkFxDcB1lUgSasPkYGP1bdraOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@oxfmt/binding-linux-x64-musl@0.62.0':
-    resolution: {integrity: sha512-4rA/URtJSTVNVAQz6Q8wf7SaRvOXVy+TizriT9hs/Y1XhLR/R+92uWKRQG8yFWRAIEBbFHJ6WevQcl/G9SXEfw==}
+  '@oxfmt/binding-linux-x64-musl@0.65.0':
+    resolution: {integrity: sha512-2azCjxdLtK4zCcIOU1dlXlU0xxfbPi6EjwWx7Ac7teWPidIIDOcIhudup83xNCKYhtqeVd/gaVDOxbUq4syXWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@oxfmt/binding-openharmony-arm64@0.62.0':
-    resolution: {integrity: sha512-mSZuFHU2ar1KLUjXpI2QBQcJ1VsOB3mOCgQXuXCpKs19dgh4u+OaovNfrWDfiJb+ihJ2+f7YFcaO9bS2dlTCXA==}
+  '@oxfmt/binding-openharmony-arm64@0.65.0':
+    resolution: {integrity: sha512-KXQ7xi1e/voP0IQaw6fG6XY4Z5+Llf1XmRSZS1t7pVFCecFJ0iXaboKmVwjFtp5MLlT5iWQrJ2U1C3GJdZ2u+Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxfmt/binding-win32-arm64-msvc@0.62.0':
-    resolution: {integrity: sha512-OfwuhkcjDlqC4EgDojtiV9mzpLqeB9KqTOWPOjLEYBVdDCVSxqW3qzp/xcIxsbtI0UgGCnKvAqYKyY25kf5JZw==}
+  '@oxfmt/binding-win32-arm64-msvc@0.65.0':
+    resolution: {integrity: sha512-2FbbjG5jEqLSLKVJwBap84uJfpn5Y5A53KEO0aUNr+zeiRB9nyPUIFMcSbZVMFLitfBytFWRNngozXYjb6Rsbw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxfmt/binding-win32-ia32-msvc@0.62.0':
-    resolution: {integrity: sha512-P9uDDNFRzghO3X8QAzhkjKhK7JvtABsVn8UYtFX7uor12IAnwNt8nNIctvfWj1JkQU/kE+fmLRPiw7XlrIHsZw==}
+  '@oxfmt/binding-win32-ia32-msvc@0.65.0':
+    resolution: {integrity: sha512-LJ+ZacAPSjegDOnSLyA1TMWAhdDrsK4el3REdr1oL2UtVBCMhO2II/Sb3cEW6mF2MfLhl8hDNCSvc7KSbgk3LQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxfmt/binding-win32-x64-msvc@0.62.0':
-    resolution: {integrity: sha512-dlI5SY7XYQCiCBafntWagCR6HcAJB/NpsLtdlPx8x08+Osz8Ok1HHz1GZuusegCe/VoJ6pAnF5a4pd5OZAq7qQ==}
+  '@oxfmt/binding-win32-x64-msvc@0.65.0':
+    resolution: {integrity: sha512-higu9cWEO6XXFzATD1jf0mCK34rNfN2H9JrJie7QB1IhleVpTh0QlLH9Ip2C1H/Nd5n0v5pvRtC+5R0uE4HpVg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/binding-android-arm-eabi@1.77.0':
-    resolution: {integrity: sha512-E06sKWS6PiI6HRxS1wyQg22HvApt01hI7fV+T3wUk3OSbaaP4a3hYGY/MIQDmASqCiRjBdpRQYkgMkqH82cWmQ==}
+  '@oxlint-tsgolint/darwin-arm64@7.0.2001':
+    resolution: {integrity: sha512-CUJEdbSZ54+Xy9OXqOhWLTKZKV0BBiV7C2i/ygyVmXtkUNXx5YCzN8DpSSshTAKktoL7S+tnQ/ftFG/i7X896w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/darwin-x64@7.0.2001':
+    resolution: {integrity: sha512-pXfBb5BqONCcgrXQNUZWXgiYmRSWJzd97S8i41VVOh6ut0tyo+cJ5FKFpczDHxiVNfj/3e7c9B4MtztNdpIVCw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/linux-arm64@7.0.2001':
+    resolution: {integrity: sha512-roP7zujb/QDPzDwEKsFFpzNHHy91/Y7oX9vQXk78ekyZtcQj1QXDIMH33gjDdHBfRl4K9pZ36xhRgrP4Zr+R8A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint-tsgolint/linux-x64@7.0.2001':
+    resolution: {integrity: sha512-UDezNqdECVmngu2TPnjaS1YoAmcTaBoI5lV9vk3VahBxoi+I5r9k3iJTT7qZoYWOXTD/7T7bNcwRgrocR6BscQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint-tsgolint/win32-arm64@7.0.2001':
+    resolution: {integrity: sha512-uJZhqB6pdXLuN+AD1F5082byyQti/NPmJA77GtcFlmT2HzRelqbNls3SaIqxpjdFgvSBF9g0yOKGBkGFg7kX8Q==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint-tsgolint/win32-x64@7.0.2001':
+    resolution: {integrity: sha512-FkDRm8hx9OwzGQqyWG1tO5QrTLRApff9DzSgpz9QZau37BR8d1VYKOxMLGf6shPZntJFoTwIIJYT68VndYDCog==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/binding-android-arm-eabi@1.80.0':
+    resolution: {integrity: sha512-RM3Plj+biQpxa5d1GOOX6ciDlcUROmm4OZ/pLTpitkQt2mJv4jhtY4cbgaetOm5UKWZe05/TGQ6o1Vl8EOHkrA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxlint/binding-android-arm64@1.77.0':
-    resolution: {integrity: sha512-NvsKz0KZxTp9cYWPLf+FXaSZwB3oO3peAjtukpOMBgse2vhQSoIIVqeO1yR0lEo/UcdZIDL18uq+kL0LzQ0ytA==}
+  '@oxlint/binding-android-arm64@1.80.0':
+    resolution: {integrity: sha512-YlO5JEf0Yr2bUUlu8O8daVcUxtcGGbcSmyV7E7nSbJbfAdxTE0PFPwgnIlw7wXJaTYjb+qs5hI5q3jxUkI7cAw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.77.0':
-    resolution: {integrity: sha512-bgjTn6nW4bQCFBvSvuHCpDD+sONvmpo4lGI4PxzMt1quBA+xYxhczk6RiCn3GZ9gY8uhaBbwhj9MdKGfu6T9DA==}
+  '@oxlint/binding-darwin-arm64@1.80.0':
+    resolution: {integrity: sha512-BULDOyO3AhsmdWfQeIUCykDt3dd7XZBGLhp1eIh56skRv01O+cNjNPwXMIbeW1x4+pxcln5if72wcRgViVo7PA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/binding-darwin-x64@1.77.0':
-    resolution: {integrity: sha512-aotaIttH1R6j1Rwhx0M0htgeZyGtVQqYNTVEYMN/UcgHPquGA6kmk9OyuDc3a2GKUQBC+3C3GVQCcrRPMYqAFA==}
+  '@oxlint/binding-darwin-x64@1.80.0':
+    resolution: {integrity: sha512-YJ4JzLw7N5TDSQFlA0hAQGHvnDZgyypm1yunObVWcWiF9KM7eGCJKYKLgTC2Fi/57OdnBhbj4OkzPGdFQJ6HyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.77.0':
-    resolution: {integrity: sha512-nNx/wta7ksRAdYvq+l4AWjXkLxEXHALhENxjj2cYbQAIR4ybaA5L+hCbE63HOmft5czQ6ks+hb8vmEAnn7YGPg==}
+  '@oxlint/binding-freebsd-x64@1.80.0':
+    resolution: {integrity: sha512-AYUIk5QnL0s8oWAYsREZwkRYy1SupJTXALo93J1TgzHywxQtdM99FecRMQ87MXEdPQ0j1TmEpeeq3fGNkpvMqg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.77.0':
-    resolution: {integrity: sha512-tMLLjM7xXtzXisVCzkOTXNCy9bZVId2wteNwjohlFDR/jY6WagpEDA1c1wu4xRc20Hojaxj+V6DSR7gbKxijWA==}
+  '@oxlint/binding-linux-arm-gnueabihf@1.80.0':
+    resolution: {integrity: sha512-9hBZVANupQ89W9dXyE0n8doCyaW5pDyGn3y6XlIMPZ+rIKuyqkr3SNUXmVJIhuvUq0NBU3RBiSXXE69l4XI6KA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-musleabihf@1.77.0':
-    resolution: {integrity: sha512-MiAFDFaqR0tmHTAyo0YDcZ5hyLREdYw/RQhc2R3cbT+8O3tB+zqPM2th9TTQ+Uo3jn/embS+DO+HyX9ztCPkOQ==}
+  '@oxlint/binding-linux-arm-musleabihf@1.80.0':
+    resolution: {integrity: sha512-SvS2uKqzY+pbfuvAHzH4338R6Zwo805GAwrIMVvK1KxoOWCIjZUdfzTCvilD7z6JK91v011+zYMryabhDo2AsQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.77.0':
-    resolution: {integrity: sha512-/xqQ3B16i1T4cyt/9Mn+4CpzhUXoBXp7kVpIwzOXNFLj5JmK1bIjsbSnX296Gg8A/o7oDtKWikFgBx0SLwztkw==}
+  '@oxlint/binding-linux-arm64-gnu@1.80.0':
+    resolution: {integrity: sha512-tCLadyqRVL3pQTRPNg7cjXKvcvS4fbyXeQHhKk5BTJ1oftQln5/yIIWbu/Xom/DX41zv2P9QGt6+D/TtQVtY3A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-musl@1.77.0':
-    resolution: {integrity: sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g==}
+  '@oxlint/binding-linux-arm64-musl@1.80.0':
+    resolution: {integrity: sha512-XfpCNRlOPcLlJl4Bn/FUhjqlR6BVavEykERBf/MV7YA9VZDa5g5znVqYhyviMafcxS9Pe/i/kPvHNO0U6svEHQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.77.0':
-    resolution: {integrity: sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg==}
+  '@oxlint/binding-linux-ppc64-gnu@1.80.0':
+    resolution: {integrity: sha512-3I4yMwcFG9NeO8ioY6JBBuKsIm5GL/x7MATt1S4tVWaxPu5HcJ+XnLUbcVBTxG8q2Wu56HSj+NmXQiVYb1lp6A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@oxlint/binding-linux-riscv64-gnu@1.77.0':
-    resolution: {integrity: sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q==}
+  '@oxlint/binding-linux-riscv64-gnu@1.80.0':
+    resolution: {integrity: sha512-E1wAKymkpe1/E8helzBKdm81OBOF+ezxRyXRMEuik3ZpWDER5CPOKZwF66RsdwW98uwZv8UTFremUQtC1CzdJA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
 
-  '@oxlint/binding-linux-riscv64-musl@1.77.0':
-    resolution: {integrity: sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA==}
+  '@oxlint/binding-linux-riscv64-musl@1.80.0':
+    resolution: {integrity: sha512-+gLRGD4sIo3+VA++iham5UxD9tKSoJ/VOrROCEXIcknrYtQg6iIQgvjN0cpiRF7N6UYC7pJbvHJlDnMge5LRpQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
 
-  '@oxlint/binding-linux-s390x-gnu@1.77.0':
-    resolution: {integrity: sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw==}
+  '@oxlint/binding-linux-s390x-gnu@1.80.0':
+    resolution: {integrity: sha512-aR0PrzHj9leW3NmzBAAP4EzdoBNoJcs9sjnIQPIwyRnBGYrRbXUIpEB5Q39AqK3PLY5JK5uEhDQDiUa1QSAstw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
-  '@oxlint/binding-linux-x64-gnu@1.77.0':
-    resolution: {integrity: sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw==}
+  '@oxlint/binding-linux-x64-gnu@1.80.0':
+    resolution: {integrity: sha512-vSVh5cSo3Xxs6ghBCcFJlpbkbENzDog1qXtoXLa/HC3aCrR4XO76GZbXmQoCPHnu99nQpdCeC3H9tdNICfDh7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint/binding-linux-x64-musl@1.77.0':
-    resolution: {integrity: sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ==}
+  '@oxlint/binding-linux-x64-musl@1.80.0':
+    resolution: {integrity: sha512-FfzBXpNQ8u7/ZI/p8bl73MeZ508Ax3hxWp3SiJpEFiC+BB9XcXy5FAZHTLKDPSzrUpxQZSZJAVdDmuJp/+HDBQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint/binding-openharmony-arm64@1.77.0':
-    resolution: {integrity: sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw==}
+  '@oxlint/binding-openharmony-arm64@1.80.0':
+    resolution: {integrity: sha512-zMzbkumtmprCgRwoYNzcB3iC39fXdJIMLMU33KdCjEGLlJGOEt1+LwQ4LF8ndLzAEKVz4BR0y3V6Xrkk3Nm3yA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxlint/binding-win32-arm64-msvc@1.77.0':
-    resolution: {integrity: sha512-Yh8w+g2Lpx7StrvtYkoz9JJvXjB9wxgFChFNb85nrXm/wj/XTwGWS1hve9+900HL7llrntYB3YP+y32E3tRqzA==}
+  '@oxlint/binding-win32-arm64-msvc@1.80.0':
+    resolution: {integrity: sha512-ib6iRcrXsk4t1fm3iKcwksyWh1ZkZXC/2mEzakl0ai2+6HZunf1WWMZ/xP9EJAvw9g9K4UVTC3NF/+G2qLrbTQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.77.0':
-    resolution: {integrity: sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA==}
+  '@oxlint/binding-win32-ia32-msvc@1.80.0':
+    resolution: {integrity: sha512-xhRWBMpLxZvgKAH6+DJZmpP+W8Y8UdQOSU1JfxSWNXsaBaRGW77j+1hCuNHlzj7OH4SPN8fYd1q0o2qrDtoVyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxlint/binding-win32-x64-msvc@1.77.0':
-    resolution: {integrity: sha512-+teyvPDZ2RjUvo+SuCqS/UhaJl1QtdW5fWT5NJTV61V5MIuIS90Db9LixmtEGvXixyttiK62P96MSu3UlpviBw==}
+  '@oxlint/binding-win32-x64-msvc@1.80.0':
+    resolution: {integrity: sha512-yAnO7lwBYQnz2pcfBPIGQQZWIX5zd5R/1aAKIF3oE+TVj7IhoHcROjOkz3sRDngzqhfPKfFaXqug5j5rE5dn6Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -3910,8 +3954,8 @@ packages:
       rolldown:
         optional: true
 
-  oxfmt@0.62.0:
-    resolution: {integrity: sha512-vxgGHTmnDU9j4CX7dDBLzxgmHxfda/yPcgJkGCMUSCwRmz+euo/V08xXLNgXTeqAB9Fhf3Pe2nO1RNKLCVgphQ==}
+  oxfmt@0.65.0:
+    resolution: {integrity: sha512-SgS5VgnP42T0zl3zWD+xoH8FCqg1SAFnSRoOT/qeoa6gxcYIqrDMOmcXIg/EWSN92Du4ogB4riuKhKd6Y4CGhw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -3923,8 +3967,12 @@ packages:
       vite-plus:
         optional: true
 
-  oxlint@1.77.0:
-    resolution: {integrity: sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg==}
+  oxlint-tsgolint@7.0.2001:
+    resolution: {integrity: sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg==}
+    hasBin: true
+
+  oxlint@1.80.0:
+    resolution: {integrity: sha512-5nTiSps4qdbCWLbxzuO00alHkEO2exR9YMN/ig6QXWrLsYSG0KaObOAM+l6oU2LcKPWoSAGYbkZIGEu1ViiWKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -5239,6 +5287,12 @@ packages:
 
 snapshots:
 
+  '@agntn/ox@0.1.0(oxfmt@0.65.0)(oxlint-tsgolint@7.0.2001)(oxlint@1.80.0(oxlint-tsgolint@7.0.2001))':
+    dependencies:
+      oxfmt: 0.65.0
+      oxlint: 1.80.0(oxlint-tsgolint@7.0.2001)
+      oxlint-tsgolint: 7.0.2001
+
   '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
@@ -6312,7 +6366,7 @@ snapshots:
       - rolldown
       - unplugin
 
-  '@nuxt/nitro-server@4.5.2(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(db0@0.3.4)(esbuild@0.28.2)(ioredis@5.11.1)(lightningcss@1.33.0)(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(oxlint@1.77.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(terser@5.49.2)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0))(rolldown@1.2.3)(rollup@4.62.4)(typescript@7.0.2)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))':
+  '@nuxt/nitro-server@4.5.2(0fa796b387275faf31dd41715fa79faa)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
@@ -6331,7 +6385,7 @@ snapshots:
       mocked-exports: 0.1.1
       nitropack: 2.13.4(rolldown@1.2.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       nostics: 1.2.0
-      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(oxlint@1.77.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(terser@5.49.2)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(oxlint@1.80.0(oxlint-tsgolint@7.0.2001))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(terser@5.49.2)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
       nypm: 0.6.9
       ohash: 2.0.11
       pathe: 2.0.3
@@ -6416,7 +6470,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.2.0
 
-  '@nuxt/vite-builder@4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@types/node@26.2.0)(esbuild@0.28.2)(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(oxlint@1.77.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(terser@5.49.2)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0))(oxlint@1.77.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(terser@5.49.2)(typescript@7.0.2)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vue@3.5.41(typescript@7.0.2))(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.5.2(02243783c711f0b39871354d527b99b7)':
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
       '@vitejs/plugin-vue': 6.0.8(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))
@@ -6434,7 +6488,7 @@ snapshots:
       knitwork: 1.3.0
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(oxlint@1.77.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(terser@5.49.2)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(oxlint@1.80.0(oxlint-tsgolint@7.0.2001))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(terser@5.49.2)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
       nypm: 0.6.9
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -6446,7 +6500,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
       vite-node: 6.0.0(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
-      vite-plugin-checker: 0.14.5(oxlint@1.77.0)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
+      vite-plugin-checker: 0.14.5(oxlint@1.80.0(oxlint-tsgolint@7.0.2001))(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       vue: 3.5.41(typescript@7.0.2)
       vue-bundle-renderer: 2.3.2
     optionalDependencies:
@@ -6749,118 +6803,136 @@ snapshots:
 
   '@oxc-project/types@0.143.0': {}
 
-  '@oxfmt/binding-android-arm-eabi@0.62.0':
+  '@oxfmt/binding-android-arm-eabi@0.65.0':
     optional: true
 
-  '@oxfmt/binding-android-arm64@0.62.0':
+  '@oxfmt/binding-android-arm64@0.65.0':
     optional: true
 
-  '@oxfmt/binding-darwin-arm64@0.62.0':
+  '@oxfmt/binding-darwin-arm64@0.65.0':
     optional: true
 
-  '@oxfmt/binding-darwin-x64@0.62.0':
+  '@oxfmt/binding-darwin-x64@0.65.0':
     optional: true
 
-  '@oxfmt/binding-freebsd-x64@0.62.0':
+  '@oxfmt/binding-freebsd-x64@0.65.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.62.0':
+  '@oxfmt/binding-linux-arm-gnueabihf@0.65.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.62.0':
+  '@oxfmt/binding-linux-arm-musleabihf@0.65.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-gnu@0.62.0':
+  '@oxfmt/binding-linux-arm64-gnu@0.65.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-musl@0.62.0':
+  '@oxfmt/binding-linux-arm64-musl@0.65.0':
     optional: true
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.62.0':
+  '@oxfmt/binding-linux-ppc64-gnu@0.65.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.62.0':
+  '@oxfmt/binding-linux-riscv64-gnu@0.65.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-musl@0.62.0':
+  '@oxfmt/binding-linux-riscv64-musl@0.65.0':
     optional: true
 
-  '@oxfmt/binding-linux-s390x-gnu@0.62.0':
+  '@oxfmt/binding-linux-s390x-gnu@0.65.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-gnu@0.62.0':
+  '@oxfmt/binding-linux-x64-gnu@0.65.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-musl@0.62.0':
+  '@oxfmt/binding-linux-x64-musl@0.65.0':
     optional: true
 
-  '@oxfmt/binding-openharmony-arm64@0.62.0':
+  '@oxfmt/binding-openharmony-arm64@0.65.0':
     optional: true
 
-  '@oxfmt/binding-win32-arm64-msvc@0.62.0':
+  '@oxfmt/binding-win32-arm64-msvc@0.65.0':
     optional: true
 
-  '@oxfmt/binding-win32-ia32-msvc@0.62.0':
+  '@oxfmt/binding-win32-ia32-msvc@0.65.0':
     optional: true
 
-  '@oxfmt/binding-win32-x64-msvc@0.62.0':
+  '@oxfmt/binding-win32-x64-msvc@0.65.0':
     optional: true
 
-  '@oxlint/binding-android-arm-eabi@1.77.0':
+  '@oxlint-tsgolint/darwin-arm64@7.0.2001':
     optional: true
 
-  '@oxlint/binding-android-arm64@1.77.0':
+  '@oxlint-tsgolint/darwin-x64@7.0.2001':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.77.0':
+  '@oxlint-tsgolint/linux-arm64@7.0.2001':
     optional: true
 
-  '@oxlint/binding-darwin-x64@1.77.0':
+  '@oxlint-tsgolint/linux-x64@7.0.2001':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.77.0':
+  '@oxlint-tsgolint/win32-arm64@7.0.2001':
     optional: true
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.77.0':
+  '@oxlint-tsgolint/win32-x64@7.0.2001':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.77.0':
+  '@oxlint/binding-android-arm-eabi@1.80.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-gnu@1.77.0':
+  '@oxlint/binding-android-arm64@1.80.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.77.0':
+  '@oxlint/binding-darwin-arm64@1.80.0':
     optional: true
 
-  '@oxlint/binding-linux-ppc64-gnu@1.77.0':
+  '@oxlint/binding-darwin-x64@1.80.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.77.0':
+  '@oxlint/binding-freebsd-x64@1.80.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-musl@1.77.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.80.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.77.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.80.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-gnu@1.77.0':
+  '@oxlint/binding-linux-arm64-gnu@1.80.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.77.0':
+  '@oxlint/binding-linux-arm64-musl@1.80.0':
     optional: true
 
-  '@oxlint/binding-openharmony-arm64@1.77.0':
+  '@oxlint/binding-linux-ppc64-gnu@1.80.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.77.0':
+  '@oxlint/binding-linux-riscv64-gnu@1.80.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.77.0':
+  '@oxlint/binding-linux-riscv64-musl@1.80.0':
     optional: true
 
-  '@oxlint/binding-win32-x64-msvc@1.77.0':
+  '@oxlint/binding-linux-s390x-gnu@1.80.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.80.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.80.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.80.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.80.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.80.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.80.0':
     optional: true
 
   '@parcel/watcher-wasm@2.6.0':
@@ -9153,16 +9225,16 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(oxlint@1.77.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(terser@5.49.2)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0):
+  nuxt@4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(oxlint@1.80.0(oxlint-tsgolint@7.0.2001))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(terser@5.49.2)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.5.6(esbuild@0.28.2)(magicast@0.5.4)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.2)(magicast@0.5.4)
       '@nuxt/devtools': 3.4.1(db0@0.3.4)(ioredis@5.11.1)(magic-string@1.1.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))
-      '@nuxt/nitro-server': 4.5.2(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(db0@0.3.4)(esbuild@0.28.2)(ioredis@5.11.1)(lightningcss@1.33.0)(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(oxlint@1.77.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(terser@5.49.2)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0))(rolldown@1.2.3)(rollup@4.62.4)(typescript@7.0.2)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))
+      '@nuxt/nitro-server': 4.5.2(0fa796b387275faf31dd41715fa79faa)
       '@nuxt/schema': 4.5.2
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))))
-      '@nuxt/vite-builder': 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@types/node@26.2.0)(esbuild@0.28.2)(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.143.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(db0@0.3.4)(esbuild@0.28.2)(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(oxlint@1.77.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(terser@5.49.2)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0))(oxlint@1.77.0)(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(terser@5.49.2)(typescript@7.0.2)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)))(vue@3.5.41(typescript@7.0.2))(yaml@2.9.0)
+      '@nuxt/vite-builder': 4.5.2(02243783c711f0b39871354d527b99b7)
       '@unhead/vue': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.28.2)(lightningcss@1.33.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))
       '@vue/shared': 3.5.41
       chokidar: 5.0.0
@@ -9407,51 +9479,61 @@ snapshots:
       '@oxc-project/types': 0.143.0
       rolldown: 1.2.3
 
-  oxfmt@0.62.0:
+  oxfmt@0.65.0:
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.62.0
-      '@oxfmt/binding-android-arm64': 0.62.0
-      '@oxfmt/binding-darwin-arm64': 0.62.0
-      '@oxfmt/binding-darwin-x64': 0.62.0
-      '@oxfmt/binding-freebsd-x64': 0.62.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.62.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.62.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.62.0
-      '@oxfmt/binding-linux-arm64-musl': 0.62.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.62.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.62.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.62.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.62.0
-      '@oxfmt/binding-linux-x64-gnu': 0.62.0
-      '@oxfmt/binding-linux-x64-musl': 0.62.0
-      '@oxfmt/binding-openharmony-arm64': 0.62.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.62.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.62.0
-      '@oxfmt/binding-win32-x64-msvc': 0.62.0
+      '@oxfmt/binding-android-arm-eabi': 0.65.0
+      '@oxfmt/binding-android-arm64': 0.65.0
+      '@oxfmt/binding-darwin-arm64': 0.65.0
+      '@oxfmt/binding-darwin-x64': 0.65.0
+      '@oxfmt/binding-freebsd-x64': 0.65.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.65.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.65.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.65.0
+      '@oxfmt/binding-linux-arm64-musl': 0.65.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.65.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.65.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.65.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.65.0
+      '@oxfmt/binding-linux-x64-gnu': 0.65.0
+      '@oxfmt/binding-linux-x64-musl': 0.65.0
+      '@oxfmt/binding-openharmony-arm64': 0.65.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.65.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.65.0
+      '@oxfmt/binding-win32-x64-msvc': 0.65.0
 
-  oxlint@1.77.0:
+  oxlint-tsgolint@7.0.2001:
     optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.77.0
-      '@oxlint/binding-android-arm64': 1.77.0
-      '@oxlint/binding-darwin-arm64': 1.77.0
-      '@oxlint/binding-darwin-x64': 1.77.0
-      '@oxlint/binding-freebsd-x64': 1.77.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.77.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.77.0
-      '@oxlint/binding-linux-arm64-gnu': 1.77.0
-      '@oxlint/binding-linux-arm64-musl': 1.77.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.77.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.77.0
-      '@oxlint/binding-linux-riscv64-musl': 1.77.0
-      '@oxlint/binding-linux-s390x-gnu': 1.77.0
-      '@oxlint/binding-linux-x64-gnu': 1.77.0
-      '@oxlint/binding-linux-x64-musl': 1.77.0
-      '@oxlint/binding-openharmony-arm64': 1.77.0
-      '@oxlint/binding-win32-arm64-msvc': 1.77.0
-      '@oxlint/binding-win32-ia32-msvc': 1.77.0
-      '@oxlint/binding-win32-x64-msvc': 1.77.0
+      '@oxlint-tsgolint/darwin-arm64': 7.0.2001
+      '@oxlint-tsgolint/darwin-x64': 7.0.2001
+      '@oxlint-tsgolint/linux-arm64': 7.0.2001
+      '@oxlint-tsgolint/linux-x64': 7.0.2001
+      '@oxlint-tsgolint/win32-arm64': 7.0.2001
+      '@oxlint-tsgolint/win32-x64': 7.0.2001
+
+  oxlint@1.80.0(oxlint-tsgolint@7.0.2001):
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.80.0
+      '@oxlint/binding-android-arm64': 1.80.0
+      '@oxlint/binding-darwin-arm64': 1.80.0
+      '@oxlint/binding-darwin-x64': 1.80.0
+      '@oxlint/binding-freebsd-x64': 1.80.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.80.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.80.0
+      '@oxlint/binding-linux-arm64-gnu': 1.80.0
+      '@oxlint/binding-linux-arm64-musl': 1.80.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.80.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.80.0
+      '@oxlint/binding-linux-riscv64-musl': 1.80.0
+      '@oxlint/binding-linux-s390x-gnu': 1.80.0
+      '@oxlint/binding-linux-x64-gnu': 1.80.0
+      '@oxlint/binding-linux-x64-musl': 1.80.0
+      '@oxlint/binding-openharmony-arm64': 1.80.0
+      '@oxlint/binding-win32-arm64-msvc': 1.80.0
+      '@oxlint/binding-win32-ia32-msvc': 1.80.0
+      '@oxlint/binding-win32-x64-msvc': 1.80.0
+      oxlint-tsgolint: 7.0.2001
 
   p-retry@4.6.2:
     dependencies:
@@ -10510,7 +10592,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.14.5(oxlint@1.77.0)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)):
+  vite-plugin-checker@0.14.5(oxlint@1.80.0(oxlint-tsgolint@7.0.2001))(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chokidar: 5.0.0
@@ -10521,7 +10603,7 @@ snapshots:
       tiny-invariant: 1.3.3
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)
     optionalDependencies:
-      oxlint: 1.77.0
+      oxlint: 1.80.0(oxlint-tsgolint@7.0.2001)
       typescript: 7.0.2
 
   vite-plugin-inspect@11.4.1(@nuxt/kit@4.5.2(magic-string@1.1.0)(magicast@0.5.4)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0))))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(yaml@2.9.0)):

--- a/src/archive.ts
+++ b/src/archive.ts
@@ -8,6 +8,7 @@ import type {
   ArchivedContent,
   ArchivedPage,
   ArchiveInterface,
+  ProviderReference,
   UnsupportedProviderRecord,
 } from "./types";
 import { getStoredContent, getStoredResponse, storeContent, storeResponse } from "./storage";
@@ -31,18 +32,103 @@ import {
 export class UnsupportedOperationError extends Error {
   readonly providers: UnsupportedProviderRecord[];
 
-  constructor(reason: string, providers: UnsupportedProviderRecord[] = []) {
+  constructor(reason: string, providers: readonly Readonly<UnsupportedProviderRecord>[] = []) {
     super(reason);
     this.name = "UnsupportedOperationError";
-    this.providers = providers;
+    this.providers = [...providers];
   }
 }
 
 type ProviderInput =
-  | ArchiveProvider
-  | ArchiveProvider[]
-  | Promise<ArchiveProvider>
-  | Promise<ArchiveProvider[]>;
+  | ProviderReference
+  | readonly ArchiveProvider[]
+  | Promise<readonly ArchiveProvider[]>;
+
+function isProviderArray(providers: ProviderInput): providers is readonly ArchiveProvider[] {
+  return Array.isArray(providers);
+}
+
+interface ListingMergeState {
+  pages: ArchivedPage[];
+  priorPageKeys: Set<string>;
+  failures: Array<{ provider: string; message: string }>;
+  unsupportedProviders: UnsupportedProviderRecord[];
+  anySuccess: boolean;
+}
+
+function mergeResponsePages(response: ArchiveResponse, state: ListingMergeState): void {
+  const responsePageKeys = new Set<string>();
+  const responseCaptureKeys = new Set<string>();
+  for (const page of response.pages) {
+    const pageKey = JSON.stringify([page.url, page.timestamp]);
+    const digest = page._meta.digest;
+    const captureIdentity =
+      typeof digest === "string" && digest.length > 0 ? digest : page.snapshot;
+    const captureKey = JSON.stringify([page.url, page.timestamp, captureIdentity]);
+    if (state.priorPageKeys.has(pageKey) || responseCaptureKeys.has(captureKey)) continue;
+    responsePageKeys.add(pageKey);
+    responseCaptureKeys.add(captureKey);
+    state.pages.push(page);
+  }
+  for (const pageKey of responsePageKeys) state.priorPageKeys.add(pageKey);
+}
+
+function collectListingResponse(response: ArchiveResponse, state: ListingMergeState): void {
+  const provider = response._meta?.provider ?? "unknown";
+  if (response.success) {
+    state.anySuccess = true;
+    mergeResponsePages(response, state);
+  } else if (response.unsupported) {
+    state.unsupportedProviders.push({
+      provider,
+      reason: response.unsupportedReason ?? "operation not supported",
+    });
+  } else if (response.error) {
+    state.failures.push({ provider, message: response.error });
+  }
+}
+
+function prefixedFailures(
+  failures: readonly Readonly<{ provider: string; message: string }>[],
+): string[] {
+  return failures.map((failure) => `${failure.provider}: ${failure.message}`);
+}
+
+function unsupportedReason(records: readonly Readonly<UnsupportedProviderRecord>[]): string {
+  return records.map((record) => `${record.provider}: ${record.reason}`).join("; ");
+}
+
+function buildCombinedListingResponse(
+  responses: readonly ArchiveResponse[],
+  state: ListingMergeState,
+  pages: readonly ArchivedPage[],
+): ArchiveResponse {
+  const providers = responses.map((response) => response._meta?.provider || "unknown");
+  const allUnsupported =
+    responses.length > 0 &&
+    state.unsupportedProviders.length === responses.length &&
+    !state.anySuccess &&
+    state.failures.length === 0;
+  const result: ArchiveResponse = {
+    success: state.anySuccess,
+    pages: [...pages],
+    _meta: {
+      source: "multiple",
+      provider: providers.join(","),
+      providerCount: providers.length,
+      errors: state.failures.length > 0 ? prefixedFailures(state.failures) : undefined,
+      unsupportedProviders:
+        state.unsupportedProviders.length > 0 ? state.unsupportedProviders : undefined,
+    },
+  };
+  if (allUnsupported) {
+    result.unsupported = true;
+    result.unsupportedReason = unsupportedReason(state.unsupportedProviders);
+  } else if (!state.anySuccess) {
+    result.error = state.failures.map((failure) => failure.message).join("; ") || undefined;
+  }
+  return result;
+}
 
 /**
  * Combine per-provider responses into a single merged ArchiveResponse.
@@ -55,90 +141,87 @@ type ProviderInput =
  *
  * @param responses - Array of per-provider responses (possibly mixed success/failure).
  * @param limit - Optional cap on the number of pages in the merged result.
+
+ *
+ * @returns {ArchiveResponse} The operation result.
  */
-export function combineResults(responses: ArchiveResponse[], limit?: number): ArchiveResponse {
-  const allPages: ArchivedPage[] = [];
-  const priorResponsePageKeys = new Set<string>();
-  const failures: Array<{ provider: string; message: string }> = [];
-  const unsupportedProviders: UnsupportedProviderRecord[] = [];
-  let anySuccess = false;
+export function combineResults(
+  responses: readonly ArchiveResponse[],
+  limit?: number,
+): ArchiveResponse {
+  const state: ListingMergeState = {
+    pages: [],
+    priorPageKeys: new Set<string>(),
+    failures: [],
+    unsupportedProviders: [],
+    anySuccess: false,
+  };
+  for (const response of responses) collectListingResponse(response, state);
+  state.pages.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+  return buildCombinedListingResponse(responses, state, limitPages(state.pages, limit));
+}
 
-  for (const response of responses) {
-    const providerSlug = response._meta?.provider ?? "unknown";
-    if (response.success) {
-      anySuccess = true;
-      const responsePageKeys = new Set<string>();
-      const responseCaptureKeys = new Set<string>();
+interface ContentMergeState {
+  failures: Array<{ provider: string; message: string }>;
+  unsupportedProviders: UnsupportedProviderRecord[];
+}
 
-      for (const page of response.pages) {
-        const pageKey = JSON.stringify([page.url, page.timestamp]);
-        const digest = page._meta.digest;
-        const captureIdentity =
-          typeof digest === "string" && digest.length > 0 ? digest : page.snapshot;
-        const captureKey = JSON.stringify([page.url, page.timestamp, captureIdentity]);
-
-        if (priorResponsePageKeys.has(pageKey) || responseCaptureKeys.has(captureKey)) {
-          continue;
-        }
-
-        responsePageKeys.add(pageKey);
-        responseCaptureKeys.add(captureKey);
-        allPages.push(page);
-      }
-
-      for (const pageKey of responsePageKeys) {
-        priorResponsePageKeys.add(pageKey);
-      }
-    } else if (response.unsupported) {
-      unsupportedProviders.push({
-        provider: providerSlug,
-        reason: response.unsupportedReason ?? "operation not supported",
-      });
-    } else if (response.error) {
-      failures.push({ provider: providerSlug, message: response.error });
-    }
+function collectContentResponse(
+  response: ArchiveContentResponse,
+  state: ContentMergeState,
+): ArchiveContentResponse | undefined {
+  const provider = response._meta?.provider ?? "unknown";
+  if (response.success && response.content) return response;
+  if (response.unsupported) {
+    state.unsupportedProviders.push({
+      provider,
+      reason: response.unsupportedReason ?? "operation not supported",
+    });
+  } else if (response.error) {
+    state.failures.push({ provider, message: response.error });
   }
+  return undefined;
+}
 
-  // newest first
-  allPages.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
-
-  const limitedPages = limitPages(allPages, limit);
-
-  const providersList = responses.map((r) => r._meta?.provider || "unknown").filter(Boolean);
-
-  // Combined response is unsupported only when every queried provider was
-  // unsupported and none produced pages or errors.
-  const allUnsupported =
-    responses.length > 0 &&
-    unsupportedProviders.length === responses.length &&
-    !anySuccess &&
-    failures.length === 0;
-
+function combineContentWinner(
+  winner: ArchiveContentResponse,
+  state: ContentMergeState,
+): ArchiveContentResponse {
   return {
-    success: anySuccess,
-    pages: limitedPages,
-    error:
-      anySuccess || allUnsupported
-        ? undefined
-        : failures.map((failure) => failure.message).join("; ") || undefined,
-    unsupported: allUnsupported || undefined,
-    unsupportedReason: allUnsupported
-      ? unsupportedProviders.map((u) => `${u.provider}: ${u.reason}`).join("; ")
-      : undefined,
+    ...winner,
     _meta: {
-      source: "multiple",
-      provider: providersList.join(","),
-      providerCount: providersList.length,
-      // Slug-prefixed, like `unsupportedProviders`: a partially successful
-      // fan-out clears `error`, so this is the only place left that says which
-      // backend failed.
-      errors:
-        failures.length > 0
-          ? failures.map((failure) => `${failure.provider}: ${failure.message}`)
-          : undefined,
-      unsupportedProviders: unsupportedProviders.length > 0 ? unsupportedProviders : undefined,
+      ...(winner._meta ?? { source: "multiple", provider: "unknown" }),
+      errors: state.failures.length > 0 ? prefixedFailures(state.failures) : undefined,
+      unsupportedProviders:
+        state.unsupportedProviders.length > 0 ? state.unsupportedProviders : undefined,
     },
   };
+}
+
+function combinedContentFailure(
+  responses: readonly ArchiveContentResponse[],
+  state: ContentMergeState,
+): ArchiveContentResponse {
+  const allUnsupported =
+    responses.length > 0 && state.unsupportedProviders.length === responses.length;
+  const result: ArchiveContentResponse = {
+    success: false,
+    _meta: {
+      source: "multiple",
+      provider: responses.map((response) => response._meta?.provider || "unknown").join(","),
+      providerCount: responses.length,
+      errors: state.failures.length > 0 ? prefixedFailures(state.failures) : undefined,
+      unsupportedProviders:
+        state.unsupportedProviders.length > 0 ? state.unsupportedProviders : undefined,
+    },
+  };
+  if (allUnsupported) {
+    result.unsupported = true;
+    result.unsupportedReason = unsupportedReason(state.unsupportedProviders);
+  } else {
+    result.error = state.failures.map((failure) => failure.message).join("; ") || undefined;
+  }
+  return result;
 }
 
 /**
@@ -150,71 +233,27 @@ export function combineResults(responses: ArchiveResponse[], limit?: number): Ar
  * body would never learn that its preferred archive was the one that failed.
  *
  * @param responses - Per-provider responses, in the order they were tried
+
+ *
+ * @returns {ArchiveContentResponse} The operation result.
  */
-export function combineContentResults(responses: ArchiveContentResponse[]): ArchiveContentResponse {
-  const failures: Array<{ provider: string; message: string }> = [];
-  const unsupportedProviders: UnsupportedProviderRecord[] = [];
-  let winner: ArchiveContentResponse | undefined;
-
-  for (const response of responses) {
-    const providerSlug = response._meta?.provider ?? "unknown";
-    if (response.success && response.content) {
-      winner ??= response;
-    } else if (response.unsupported) {
-      unsupportedProviders.push({
-        provider: providerSlug,
-        reason: response.unsupportedReason ?? "operation not supported",
-      });
-    } else if (response.error) {
-      failures.push({ provider: providerSlug, message: response.error });
-    }
-  }
-
-  // A single provider's answer is already the whole answer; rewrapping it would
-  // only lose `fromCache` and the provider's own metadata.
+export function combineContentResults(
+  responses: readonly ArchiveContentResponse[],
+): ArchiveContentResponse {
   if (responses.length <= 1) {
     return responses[0] ?? { success: false, error: "No providers were queried" };
   }
 
-  const errors =
-    failures.length > 0
-      ? failures.map((failure) => `${failure.provider}: ${failure.message}`)
-      : undefined;
-  const unsupported = unsupportedProviders.length > 0 ? unsupportedProviders : undefined;
-
-  if (winner) {
-    return {
-      ...winner,
-      _meta: {
-        ...(winner._meta ?? { source: "multiple", provider: "unknown" }),
-        errors,
-        unsupportedProviders: unsupported,
-      },
-    };
+  const state: ContentMergeState = { failures: [], unsupportedProviders: [] };
+  let winner: ArchiveContentResponse | undefined;
+  for (const response of responses) {
+    const candidate = collectContentResponse(response, state);
+    winner ??= candidate;
   }
-
-  const allUnsupported = responses.length > 0 && unsupportedProviders.length === responses.length;
-
-  return {
-    success: false,
-    error: allUnsupported
-      ? undefined
-      : failures.map((failure) => failure.message).join("; ") || undefined,
-    unsupported: allUnsupported || undefined,
-    unsupportedReason: allUnsupported
-      ? unsupportedProviders.map((record) => `${record.provider}: ${record.reason}`).join("; ")
-      : undefined,
-    _meta: {
-      source: "multiple",
-      provider: responses.map((response) => response._meta?.provider || "unknown").join(","),
-      providerCount: responses.length,
-      errors,
-      unsupportedProviders: unsupported,
-    },
-  };
+  return winner ? combineContentWinner(winner, state) : combinedContentFailure(responses, state);
 }
 
-/**
+/*
  * Drops the pages outside the requested window.
  *
  * Providers that can narrow their own index query already have; this is the
@@ -236,16 +275,53 @@ function windowPages(response: ArchiveResponse, from: string, to: string): Archi
   return pages.length === response.pages.length ? response : { ...response, pages };
 }
 
-/** One shared clamp, so the merge and the windowed paths cannot drift on limit semantics. */
-function limitPages(pages: ArchivedPage[], limit: number | undefined): ArchivedPage[] {
-  if (typeof limit !== "number" || !Number.isFinite(limit)) return pages;
-  return pages.length <= limit ? pages : pages.slice(0, Math.max(0, limit));
+/* One shared clamp, so the merge and the windowed paths cannot drift on limit semantics. */
+function limitPages(pages: readonly ArchivedPage[], limit: number | undefined): ArchivedPage[] {
+  if (typeof limit !== "number" || !Number.isFinite(limit)) return [...pages];
+  return pages.length <= limit ? [...pages] : pages.slice(0, Math.max(0, limit));
 }
 
-/** Caps the pages of one filtered response, the way the lifted provider limit would have. */
+/* Caps the pages of one filtered response, the way the lifted provider limit would have. */
 function capPages(response: ArchiveResponse, limit: number | undefined): ArchiveResponse {
   const pages = limitPages(response.pages, limit);
   return pages === response.pages ? response : { ...response, pages };
+}
+
+type FailedArchiveResponse = ArchiveResponse | ArchiveContentResponse;
+
+function responseUnsupportedProviders(
+  response: FailedArchiveResponse,
+): UnsupportedProviderRecord[] {
+  if (response._meta?.unsupportedProviders) return [...response._meta.unsupportedProviders];
+  if (!response._meta?.provider) return [];
+  return [
+    {
+      provider: response._meta.provider,
+      reason: response.unsupportedReason ?? "operation not supported",
+    },
+  ];
+}
+
+function archiveFailureMessage(response: FailedArchiveResponse, fallback: string): string {
+  const parts: string[] = [];
+  if (response.error) parts.push(response.error);
+  const unsupported = response._meta?.unsupportedProviders;
+  if (unsupported?.length) {
+    parts.push(
+      `unsupported: ${unsupported.map((record) => `${record.provider} (${record.reason})`).join(", ")}`,
+    );
+  }
+  return parts.length > 0 ? parts.join("; ") : fallback;
+}
+
+function throwArchiveFailure(response: FailedArchiveResponse, fallback: string): never {
+  if (response.unsupported) {
+    throw new UnsupportedOperationError(
+      response.unsupportedReason ?? "operation not supported by any queried provider",
+      responseUnsupportedProviders(response),
+    );
+  }
+  throw new Error(archiveFailureMessage(response, fallback));
 }
 
 /**
@@ -264,8 +340,8 @@ export class Archive implements ArchiveInterface {
   private readonly providersInput: ProviderInput;
   private resolvedProviders: ArchiveProvider[] | undefined;
 
-  constructor(providers: ProviderInput, options?: ArchiveOptions) {
-    this.providersInput = Array.isArray(providers) ? [...providers] : providers;
+  constructor(providers: ProviderInput, options?: Readonly<ArchiveOptions>) {
+    this.providersInput = isProviderArray(providers) ? [...providers] : providers;
     this.options = options;
     this.resolveProviders = this.resolveProviders.bind(this);
     this.snapshots = this.snapshots.bind(this);
@@ -280,6 +356,9 @@ export class Archive implements ArchiveInterface {
    * Force-resolve providers immediately. Normally resolution is deferred
    * until the first query so `createArchive(providers.all())` stays cheap
    * even when never called. Public for consumers that want eager init.
+
+   *
+   * @returns {Promise<ArchiveProvider[]>} A promise resolving to the operation result.
    */
   async resolveProviders(): Promise<ArchiveProvider[]> {
     if (this.resolvedProviders) {
@@ -287,17 +366,23 @@ export class Archive implements ArchiveInterface {
     }
 
     const result = await Promise.resolve(this.providersInput);
-    this.resolvedProviders = Array.isArray(result) ? [...result] : [result];
+    this.resolvedProviders = isProviderArray(result) ? [...result] : [result];
     return [...this.resolvedProviders];
   }
 
   /**
    * Fetch from a single provider, honoring cache and error-normalization.
+
+   *
+   * @param provider - Provider.
+   * @param domain - Domain.
+   * @param requestOptions - Request Options.
+   * @returns {Promise<ArchiveResponse>} A promise resolving to the operation result.
    */
   private async fetchFromProvider(
-    provider: ArchiveProvider,
+    provider: Readonly<ArchiveProvider>,
     domain: string,
-    requestOptions: ArchiveOptions,
+    requestOptions: Readonly<ArchiveOptions>,
   ): Promise<ArchiveResponse> {
     // Try cache first
     if (requestOptions.cache !== false) {
@@ -344,7 +429,7 @@ export class Archive implements ArchiveInterface {
    *
    * @param domain - The domain to search for in archive services (e.g., "example.com")
    * @param listOptions - Request-specific options that override the default options
-   * @returns Promise resolving to ArchiveResponse with pages, metadata and status
+   * @returns {Promise<ArchiveResponse>} Promise resolving to ArchiveResponse with pages, metadata and status
    *
    * @example
    * ```js
@@ -364,7 +449,10 @@ export class Archive implements ArchiveInterface {
    * })
    * ```
    */
-  async snapshots(domain: string, listOptions?: ArchiveOptions): Promise<ArchiveResponse> {
+  async snapshots(
+    domain: string,
+    listOptions?: Readonly<ArchiveOptions>,
+  ): Promise<ArchiveResponse> {
     const {
       from: rawFrom,
       to: rawTo,
@@ -390,7 +478,7 @@ export class Archive implements ArchiveInterface {
       return { provider, windowFrom, windowTo };
     });
 
-    /**
+    /*
      * One provider's windowed listing. The fetch runs with every limit lifted,
      * as an explicit undefined so the provider's own cascade cannot restore an
      * init-level value, and with the validated digits in the request options,
@@ -405,7 +493,7 @@ export class Archive implements ArchiveInterface {
       provider,
       windowFrom,
       windowTo,
-    }: (typeof windowed)[number]): Promise<ArchiveResponse> => {
+    }: Readonly<(typeof windowed)[number]>): Promise<ArchiveResponse> => {
       if (!windowFrom && !windowTo) {
         return this.fetchFromProvider(provider, domain, restOptions);
       }
@@ -447,8 +535,8 @@ export class Archive implements ArchiveInterface {
    *
    * @param domain - The domain to search for in archive services
    * @param listOptions - Request-specific options that override the defaults
-   * @returns Promise resolving to array of ArchivedPage objects
-   * @throws Error if the request fails
+   * @returns {Promise<ArchivedPage[]>} Promise resolving to array of ArchivedPage objects
+   * @throws {Error} Error if the request fails
    *
    * @example
    * ```js
@@ -463,56 +551,28 @@ export class Archive implements ArchiveInterface {
    * }
    * ```
    */
-  async getPages(domain: string, listOptions?: ArchiveOptions): Promise<ArchivedPage[]> {
+  async getPages(domain: string, listOptions?: Readonly<ArchiveOptions>): Promise<ArchivedPage[]> {
     const res = await this.snapshots(domain, listOptions);
     if (res.success) {
       return res.pages;
     }
 
-    // Whole call was structurally unsupported: throw the dedicated subclass.
-    // Synthesize `.providers` from the raw single-provider response when
-    // `combineResults` was bypassed (`_meta.unsupportedProviders` only exists
-    // for multi-provider runs).
-    if (res.unsupported) {
-      const providers =
-        res._meta?.unsupportedProviders ??
-        (res._meta?.provider
-          ? [
-              {
-                provider: res._meta.provider,
-                reason: res.unsupportedReason ?? "operation not supported",
-              },
-            ]
-          : []);
-      throw new UnsupportedOperationError(
-        res.unsupportedReason ?? "operation not supported by any queried provider",
-        providers,
-      );
-    }
-
-    // Mixed runtime error + partial unsupported, or pure runtime error.
-    // Surface both layers in the message so callers see the full picture
-    // even though the throw type is generic Error.
-    const messageParts: string[] = [];
-    if (res.error) messageParts.push(res.error);
-    if (res._meta?.unsupportedProviders?.length) {
-      messageParts.push(
-        "unsupported: " +
-          res._meta.unsupportedProviders.map((u) => `${u.provider} (${u.reason})`).join(", "),
-      );
-    }
-    throw new Error(
-      messageParts.length > 0 ? messageParts.join("; ") : "Failed to fetch archive snapshots",
-    );
+    throwArchiveFailure(res, "Failed to fetch archive snapshots");
   }
 
   /**
    * Read one archived capture's body from a single provider, honoring the cache.
+
+   *
+   * @param provider - Provider.
+   * @param url - Url.
+   * @param requestOptions - Request Options.
+   * @returns {Promise<ArchiveContentResponse>} A promise resolving to the operation result.
    */
   private async readContentFromProvider(
-    provider: ArchiveProvider,
+    provider: Readonly<ArchiveProvider>,
     url: string,
-    requestOptions: ArchiveContentOptions,
+    requestOptions: Readonly<ArchiveContentOptions>,
   ): Promise<ArchiveContentResponse> {
     const providerSlug = provider.slug ?? provider.name;
 
@@ -562,7 +622,7 @@ export class Archive implements ArchiveInterface {
    *
    * @param url - Original URL, or a playback URL printed by `snapshots()`
    * @param contentOptions - Request options; `timestamp` selects the capture
-   * @returns Promise resolving to the capture, or to the reasons nobody had it
+   * @returns {Promise<ArchiveContentResponse>} Promise resolving to the capture, or to the reasons nobody had it
    *
    * @example
    * ```js
@@ -577,7 +637,7 @@ export class Archive implements ArchiveInterface {
    */
   async content(
     url: string,
-    contentOptions?: ArchiveContentOptions,
+    contentOptions?: Readonly<ArchiveContentOptions>,
   ): Promise<ArchiveContentResponse> {
     const mergedOptions = await mergeOptions<ArchiveContentOptions>(this.options, contentOptions);
     const providerArray = await this.resolveProviders();
@@ -616,44 +676,20 @@ export class Archive implements ArchiveInterface {
    *
    * @param url - Original URL, or a playback URL printed by `snapshots()`
    * @param contentOptions - Request options; `timestamp` selects the capture
-   * @returns Promise resolving to the archived capture
-   * @throws `UnsupportedOperationError` when every queried provider lacks the
+   * @returns {Promise<ArchivedContent>} Promise resolving to the archived capture
+   * @throws {Error} `UnsupportedOperationError` when every queried provider lacks the
    * operation, and a generic `Error` when the read failed for any other reason
    */
-  async getContent(url: string, contentOptions?: ArchiveContentOptions): Promise<ArchivedContent> {
+  async getContent(
+    url: string,
+    contentOptions?: Readonly<ArchiveContentOptions>,
+  ): Promise<ArchivedContent> {
     const res = await this.content(url, contentOptions);
     if (res.success && res.content) {
       return res.content;
     }
 
-    if (res.unsupported) {
-      const providers =
-        res._meta?.unsupportedProviders ??
-        (res._meta?.provider
-          ? [
-              {
-                provider: res._meta.provider,
-                reason: res.unsupportedReason ?? "operation not supported",
-              },
-            ]
-          : []);
-      throw new UnsupportedOperationError(
-        res.unsupportedReason ?? "operation not supported by any queried provider",
-        providers,
-      );
-    }
-
-    const messageParts: string[] = [];
-    if (res.error) messageParts.push(res.error);
-    if (res._meta?.unsupportedProviders?.length) {
-      messageParts.push(
-        "unsupported: " +
-          res._meta.unsupportedProviders.map((u) => `${u.provider} (${u.reason})`).join(", "),
-      );
-    }
-    throw new Error(
-      messageParts.length > 0 ? messageParts.join("; ") : "Failed to read archived content",
-    );
+    throwArchiveFailure(res, "Failed to read archived content");
   }
 
   /**
@@ -661,7 +697,7 @@ export class Archive implements ArchiveInterface {
    * Allows for dynamically extending the archive with additional providers.
    *
    * @param provider - The provider or Promise resolving to a provider to add
-   * @returns The archive instance for method chaining
+   * @returns {Promise<ArchiveInterface>} The archive instance for method chaining
    *
    * @example
    * ```js
@@ -676,7 +712,7 @@ export class Archive implements ArchiveInterface {
    * await archive.use(providers.commoncrawl())
    * ```
    */
-  async use(provider: ArchiveProvider | Promise<ArchiveProvider>): Promise<ArchiveInterface> {
+  async use(provider: ProviderReference): Promise<ArchiveInterface> {
     const resolvedProvider = await Promise.resolve(provider);
     const currentProviders = await this.resolveProviders();
     this.resolvedProviders = [...currentProviders, resolvedProvider];
@@ -688,7 +724,7 @@ export class Archive implements ArchiveInterface {
    * More efficient than calling use() multiple times.
    *
    * @param newProviders - Array of providers or Promises resolving to providers
-   * @returns The archive instance for method chaining
+   * @returns {Promise<ArchiveInterface>} The archive instance for method chaining
    *
    * @example
    * ```js
@@ -703,9 +739,7 @@ export class Archive implements ArchiveInterface {
    * ])
    * ```
    */
-  async useAll(
-    newProviders: (ArchiveProvider | Promise<ArchiveProvider>)[],
-  ): Promise<ArchiveInterface> {
+  async useAll(newProviders: readonly ProviderReference[]): Promise<ArchiveInterface> {
     const resolvedNewProviders = await Promise.all(newProviders.map((p) => Promise.resolve(p)));
     const currentProviders = await this.resolveProviders();
     this.resolvedProviders = [...currentProviders, ...resolvedNewProviders];
@@ -721,7 +755,7 @@ export class Archive implements ArchiveInterface {
  *
  * @param providers - Single provider, array of providers, or Promise(s) resolving to provider(s)
  * @param options - Default options applied to all queries (limit, cache, ttl, concurrency, etc.)
- * @returns Archive client with methods for fetching and managing archive data
+ * @returns {ArchiveInterface} Archive client with methods for fetching and managing archive data
  *
  * @example
  * ```js
@@ -744,12 +778,8 @@ export class Archive implements ArchiveInterface {
  * ```
  */
 export function createArchive(
-  providers:
-    | ArchiveProvider
-    | ArchiveProvider[]
-    | Promise<ArchiveProvider>
-    | Promise<ArchiveProvider[]>,
-  options?: ArchiveOptions,
+  providers: ProviderInput,
+  options?: Readonly<ArchiveOptions>,
 ): ArchiveInterface {
   return new Archive(providers, options);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,6 +54,24 @@ const getDefaultConfig = () =>
     },
   }) as ArchivesConfig;
 
+type ConfigLayer = Readonly<{
+  storage?: Readonly<ArchivesConfig["storage"]>;
+  performance?: Readonly<ArchivesConfig["performance"]>;
+  $env?: Readonly<Record<string, ConfigLayer>>;
+  $development?: ConfigLayer;
+  $production?: ConfigLayer;
+  $test?: ConfigLayer;
+}>;
+
+type ResolveConfigOptions = Readonly<{
+  cwd?: string;
+  defaults?: ConfigLayer;
+  overrides?: ConfigLayer;
+  envName?: string | false;
+  configFile?: string;
+  rcFile?: string;
+}>;
+
 // Cache for resolved config
 let cachedConfig: ArchivesConfig | undefined;
 
@@ -78,17 +96,12 @@ export function setConfigCwd(cwd: string): void {
 
 /**
  * Load Archives configuration from all available sources
+
+ *
+ * @param options - Options.
+ * @returns {Promise<ArchivesConfig>} A promise resolving to the operation result.
  */
-export async function resolveConfig(
-  options: {
-    cwd?: string;
-    defaults?: Partial<ArchivesConfig>;
-    overrides?: Partial<ArchivesConfig>;
-    envName?: string | false;
-    configFile?: string;
-    rcFile?: string;
-  } = {},
-): Promise<ArchivesConfig> {
+export async function resolveConfig(options: ResolveConfigOptions = {}): Promise<ArchivesConfig> {
   const shouldCache = Object.values(options).every((value) => value === undefined);
   if (shouldCache && cachedConfig) {
     return cachedConfig;
@@ -97,17 +110,7 @@ export async function resolveConfig(
   const defaults = getDefaultConfig();
 
   // Load config using c12
-  const { config } = await loadConfig({
-    name: "archives",
-    defaults,
-    defaultConfig: options.defaults || undefined,
-    overrides: options.overrides || undefined,
-    envName: options.envName ?? process.env.NODE_ENV,
-    cwd: options.cwd ?? configCwd,
-    configFile: options.configFile,
-    rcFile: options.rcFile === undefined ? ".archives" : options.rcFile,
-    packageJson: true,
-  });
+  const { config } = await loadArchivesConfig(options, defaults);
 
   // Apply post-processing
   const resolvedConfig = await postProcessConfig(config as ArchivesConfig, defaults);
@@ -119,33 +122,39 @@ export async function resolveConfig(
   return resolvedConfig;
 }
 
-/**
+async function loadArchivesConfig(options: ResolveConfigOptions, defaults: ArchivesConfig) {
+  return loadConfig({
+    name: "archives",
+    defaults,
+    defaultConfig: options.defaults ?? undefined,
+    overrides: options.overrides ?? undefined,
+    envName: options.envName ?? process.env.NODE_ENV,
+    cwd: options.cwd ?? configCwd,
+    configFile: options.configFile,
+    rcFile: options.rcFile ?? ".archives",
+    packageJson: true,
+  });
+}
+
+/*
  * Apply additional configuration processing and validation
  */
 async function postProcessConfig(
   config: ArchivesConfig,
   defaults: ArchivesConfig,
 ): Promise<ArchivesConfig> {
-  // Ensure required properties exist
-  if (!config.storage) {
-    config.storage = { ...defaults.storage };
-  }
+  const storage = {
+    ...defaults.storage,
+    ...config.storage,
+    driver: config.storage?.driver ?? defaults.storage.driver ?? memoryDriver(),
+    prefix: config.storage?.prefix || defaults.storage.prefix,
+  };
 
-  if (!config.performance) {
-    config.performance = { ...defaults.performance };
-  }
-
-  // Default storage prefix
-  if (!config.storage.prefix) {
-    config.storage.prefix = defaults.storage.prefix;
-  }
-
-  // Default storage driver
-  if (!config.storage.driver) {
-    config.storage.driver = memoryDriver();
-  }
-
-  return config;
+  return {
+    ...config,
+    storage,
+    performance: { ...defaults.performance, ...config.performance },
+  };
 }
 
 /**
@@ -157,9 +166,11 @@ export function resetConfig(): void {
 
 /**
  * Get the current configuration or resolve it if not already loaded
+
+ *
+ * @param options - Options.
+ * @returns {Promise<ArchivesConfig>} A promise resolving to the operation result.
  */
-export async function getConfig(
-  options?: Parameters<typeof resolveConfig>[0],
-): Promise<ArchivesConfig> {
+export async function getConfig(options?: ResolveConfigOptions): Promise<ArchivesConfig> {
   return resolveConfig(options);
 }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -43,8 +43,8 @@ interface ToolDefinition {
   inputSchema: TSchema;
   annotations: Tool["annotations"];
   execute(
-    args: Record<string, unknown>,
-    signal?: AbortSignal,
+    args: Readonly<Record<string, unknown>>,
+    signal?: Readonly<AbortSignal>,
   ): ToolResult<unknown> | Promise<ToolResult<unknown>>;
 }
 
@@ -280,7 +280,7 @@ const tools: ToolDefinition[] = [
   },
 ];
 
-/** Formats the first TypeBox validation failure for an MCP client. */
+/* Formats the first TypeBox validation failure for an MCP client. */
 function validationError(schema: TSchema, value: unknown): string {
   const first = Value.Errors(schema, value)[0];
   if (!first) return "Invalid arguments";
@@ -299,7 +299,7 @@ function validationError(schema: TSchema, value: unknown): string {
   return `Invalid arguments at ${path}: ${detail}`;
 }
 
-/** Names the arguments a closed schema does not declare. */
+/* Names the arguments a closed schema does not declare. */
 function unknownProperties(schema: TSchema, value: unknown): string[] {
   const node = schema as Record<string, unknown>;
   if (node["additionalProperties"] !== false) return [];
@@ -308,7 +308,7 @@ function unknownProperties(schema: TSchema, value: unknown): string[] {
   return Object.keys(value).filter((key) => !declared.has(key));
 }
 
-/** Lists the literals a union at `instancePath` accepts, when that is what failed. */
+/* Lists the literals a union at `instancePath` accepts, when that is what failed. */
 function allowedValues(schema: TSchema, instancePath: string): string | undefined {
   let node = schema as Record<string, unknown>;
   for (const segment of instancePath.split("/").filter(Boolean)) {
@@ -325,7 +325,7 @@ function allowedValues(schema: TSchema, instancePath: string): string | undefine
   return literals.map((literal) => String(literal)).join(", ");
 }
 
-/**
+/*
  * Converts a shared tool result to the MCP text-result contract.
  *
  * `details` is dropped and `structuredContent` is never set: clients that see
@@ -335,7 +335,7 @@ function toCallToolResult(result: ToolResult<unknown>): CallToolResult {
   return { content: result.content, ...(result.isError ? { isError: true } : {}) };
 }
 
-/** Error text is model- or provider-controlled, so it crosses the same boundary. */
+/* Error text is model- or provider-controlled, so it crosses the same boundary. */
 function errorResult(text: string): CallToolResult {
   return { content: [{ type: "text", text: sanitizeTerminalText(text) }], isError: true };
 }
@@ -348,6 +348,9 @@ function errorResult(text: string): CallToolResult {
  * does not implement Standard Schema, and this package's tool schemas are TypeBox,
  * shared in shape with the Pi and OMP extensions. The high-level API would force a
  * second definition of every parameter.
+
+ *
+ * @returns {Server} The operation result.
  */
 export function createMcpServer(): Server {
   const toolsByName = new Map(tools.map((tool) => [tool.name, tool]));

--- a/src/providers/_lazy-import.ts
+++ b/src/providers/_lazy-import.ts
@@ -4,7 +4,7 @@
  *
  * @template T - Module namespace returned by the import.
  * @param load - Dynamic import operation.
- * @returns A retryable lazy loader.
+ * @returns {() => Promise<T>} A retryable lazy loader.
  */
 export function createRetryableLazyImport<T>(load: () => Promise<T>): () => Promise<T> {
   let pending: Promise<T> | undefined;

--- a/src/providers/archive-it.ts
+++ b/src/providers/archive-it.ts
@@ -35,6 +35,34 @@ const BASE_URL = "https://wayback.archive-it.org";
  */
 const CONTENT_CAPTURE_LIMIT = 200;
 
+interface ArchiveItCacheOptions {
+  collection: string;
+  collapse?: string;
+  filter?: string;
+  limit?: number;
+}
+
+function effectiveCacheOptions(
+  request: Readonly<Partial<ArchiveItOptions>> | undefined,
+  defaults: Readonly<Partial<ArchiveItOptions>>,
+): ArchiveItCacheOptions {
+  return {
+    collection: String(request?.collection ?? defaults.collection).trim(),
+    collapse: request?.collapse ?? defaults.collapse,
+    filter: request?.filter ?? defaults.filter,
+    limit: request?.limit === undefined ? defaults.limit : undefined,
+  };
+}
+
+function archiveItCacheKey(options: Readonly<ArchiveItCacheOptions>): string {
+  const parts = [`collection=${encodeURIComponent(options.collection)}`];
+  if (options.collapse !== undefined)
+    parts.push(`collapse=${encodeURIComponent(options.collapse)}`);
+  if (options.filter !== undefined) parts.push(`filter=${encodeURIComponent(options.filter)}`);
+  if (options.limit !== undefined) parts.push(`limit=${options.limit}`);
+  return parts.join(":");
+}
+
 /**
  * Archive-It collection archive provider.
  */
@@ -42,26 +70,20 @@ export class ArchiveItProvider extends BaseProvider<ArchiveItOptions> {
   readonly name = "Archive-It";
   readonly slug = "archive-it";
 
-  constructor(options: ArchiveItOptions) {
+  constructor(options: Readonly<ArchiveItOptions>) {
     super(options);
   }
 
   /**
    * Cache key extension for the collection and filters that change the CDX result set.
+
+   *
+   * @param options - Options.
+   * @returns {string} The resulting string.
    */
-  override cacheKey(options?: ArchiveOptions): string {
+  override cacheKey(options?: Readonly<ArchiveOptions>): string {
     const requestOptions = options as Partial<ArchiveItOptions> | undefined;
-    const collection = String(requestOptions?.collection ?? this.options.collection).trim();
-    const collapse = requestOptions?.collapse ?? this.options.collapse;
-    const filter = requestOptions?.filter ?? this.options.filter;
-    const limit = requestOptions?.limit === undefined ? this.options.limit : undefined;
-    const parts = [`collection=${encodeURIComponent(collection)}`];
-
-    if (collapse !== undefined) parts.push(`collapse=${encodeURIComponent(collapse)}`);
-    if (filter !== undefined) parts.push(`filter=${encodeURIComponent(filter)}`);
-    if (limit !== undefined) parts.push(`limit=${limit}`);
-
-    return parts.join(":");
+    return archiveItCacheKey(effectiveCacheOptions(requestOptions, this.options));
   }
 
   /**
@@ -70,10 +92,15 @@ export class ArchiveItProvider extends BaseProvider<ArchiveItOptions> {
    * The window bounds are normalized here too, not only in `Archive.snapshots`:
    * the provider is a public export, and the CDX index does not read a raw ISO
    * date as an instant.
+
+   *
+   * @param domain - Domain.
+   * @param reqOptions - Req Options.
+   * @returns {Promise<ArchiveResponse>} A promise resolving to the operation result.
    */
   async snapshots(
     domain: string,
-    reqOptions: Partial<ArchiveItOptions> = {},
+    reqOptions: Readonly<Partial<ArchiveItOptions>> = {},
   ): Promise<ArchiveResponse> {
     try {
       const options = await this.resolveOptions(reqOptions);
@@ -111,7 +138,7 @@ export class ArchiveItProvider extends BaseProvider<ArchiveItOptions> {
 
       return createSuccessResponse(pages, "archive-it", {
         collection,
-        queryParams: fetchOptions.params || {},
+        queryParams: fetchOptions.params ?? {},
       });
     } catch (error) {
       return createErrorResponse(error, "archive-it");
@@ -124,10 +151,15 @@ export class ArchiveItProvider extends BaseProvider<ArchiveItOptions> {
    * Archive-It replays captures through the same Wayback machinery as the
    * Internet Archive, so the `id_` modifier returns the original response here
    * too. Only the host and the collection segment differ.
+
+   *
+   * @param url - Url.
+   * @param reqOptions - Req Options.
+   * @returns {Promise<ArchiveContentResponse>} A promise resolving to the operation result.
    */
   override async content(
     url: string,
-    reqOptions: Partial<ArchiveItOptions> & ArchiveContentOptions = {},
+    reqOptions: Readonly<Partial<ArchiveItOptions> & ArchiveContentOptions> = {},
   ): Promise<ArchiveContentResponse> {
     try {
       const options = await this.resolveContentOptions(reqOptions);
@@ -174,7 +206,7 @@ export class ArchiveItProvider extends BaseProvider<ArchiveItOptions> {
     collection: string,
     target: string,
     wanted: string,
-    options: ArchiveContentOptions,
+    options: Readonly<ArchiveContentOptions>,
   ): Promise<Array<{ original: string; timestamp: string; status?: number }>> {
     const params: Record<string, string> = {
       url: target,
@@ -222,7 +254,7 @@ export class ArchiveItProvider extends BaseProvider<ArchiveItOptions> {
   }
 }
 
-/** Archive-It queries are collection-scoped; a missing or non-numeric id has no endpoint. */
+/* Archive-It queries are collection-scoped; a missing or non-numeric id has no endpoint. */
 function requireCollection(collection: ArchiveItOptions["collection"] | undefined): string {
   const value = String(collection ?? "").trim();
   if (!/^\d+$/.test(value)) {
@@ -231,6 +263,6 @@ function requireCollection(collection: ArchiveItOptions["collection"] | undefine
   return value;
 }
 
-export default function archiveIt(options: ArchiveItOptions): ArchiveItProvider {
+export default function archiveIt(options: Readonly<ArchiveItOptions>): ArchiveItProvider {
   return new ArchiveItProvider(options);
 }

--- a/src/providers/archive-today.ts
+++ b/src/providers/archive-today.ts
@@ -23,6 +23,69 @@ import {
 } from "../utils";
 import { BaseProvider } from "./base-provider";
 
+interface ArchiveTodayCapture {
+  url: string;
+  snapshot: string;
+  timestamp: string;
+}
+
+function selectArchiveTodayCapture(
+  pages: readonly ArchivedPage[],
+  requestedUrl: string,
+  wanted: string,
+): ArchiveTodayCapture | undefined {
+  const captures = pages.map((page) => ({
+    url: page.url,
+    snapshot: page.snapshot,
+    timestamp: (page._meta as ArchiveTodayMetadata).hash,
+  }));
+  return selectCapture(
+    preferSameUrl(captures, requestedUrl, (candidate) => candidate.url),
+    wanted,
+  );
+}
+
+function missingCaptureResponse(target: string, wanted: string): ArchiveContentResponse {
+  const near = wanted ? ` near ${wanted}` : "";
+  return createContentErrorResponse(
+    `No Archive.today capture for ${target}${near}`,
+    "archive-today",
+    { requestedTimestamp: wanted || undefined },
+  );
+}
+
+function archiveTodayPage(
+  match: readonly string[],
+  target: string,
+  position: number,
+): ArchivedPage | undefined {
+  const [, snapshotUrl, timestamp, origUrl, datetime] = match;
+  if (!origUrl.includes(target)) return undefined;
+  try {
+    const parsedDate = new Date(datetime);
+    const isoTimestamp = Number.isNaN(parsedDate.getTime())
+      ? waybackTimestampToISO(timestamp)
+      : parsedDate.toISOString();
+    if (!isoTimestamp) {
+      consola.debug("[archive-today] Dropping memento with unreadable capture time", {
+        datetime,
+        snapshot: snapshotUrl,
+      });
+      return undefined;
+    }
+    const normalizedOriginal = origUrl.includes("://") ? origUrl : `https://${origUrl}`;
+    return {
+      url: withoutTrailingSlash(cleanDoubleSlashes(normalizedOriginal)),
+      timestamp: isoTimestamp,
+      snapshot: withoutTrailingSlash(snapshotUrl),
+      _meta: { hash: timestamp, raw_date: datetime, position } as ArchiveTodayMetadata,
+    };
+  } catch (error) {
+    consola.error("Error parsing archive.today snapshot:", error);
+    return undefined;
+  }
+}
+
 /**
  * Archive.today archive provider. Uses the Memento timemap endpoint.
  */
@@ -32,8 +95,16 @@ export class ArchiveTodayProvider extends BaseProvider<ArchiveTodayOptions> {
 
   /**
    * Fetch archived snapshots from Archive.today.
+
+   *
+   * @param domain - Domain.
+   * @param reqOptions - Req Options.
+   * @returns {Promise<ArchiveResponse>} A promise resolving to the operation result.
    */
-  async snapshots(domain: string, reqOptions: ArchiveTodayOptions = {}): Promise<ArchiveResponse> {
+  async snapshots(
+    domain: string,
+    reqOptions: Readonly<ArchiveTodayOptions> = {},
+  ): Promise<ArchiveResponse> {
     const cleanDomain = normalizeDomain(domain, false);
 
     try {
@@ -72,10 +143,15 @@ export class ArchiveTodayProvider extends BaseProvider<ArchiveTodayOptions> {
    * on this side would make every returned capture fail the match and read as
    * never archived. The same fragment-free form feeds the same-url narrowing,
    * which still wants the caller's scheme, so it is not the timemap target.
+
+   *
+   * @param url - Url.
+   * @param reqOptions - Req Options.
+   * @returns {Promise<ArchiveContentResponse>} A promise resolving to the operation result.
    */
   override async content(
     url: string,
-    reqOptions: Partial<ArchiveTodayOptions> & ArchiveContentOptions = {},
+    reqOptions: Readonly<Partial<ArchiveTodayOptions> & ArchiveContentOptions> = {},
   ): Promise<ArchiveContentResponse> {
     try {
       const options = await this.resolveContentOptions(reqOptions);
@@ -87,22 +163,8 @@ export class ArchiveTodayProvider extends BaseProvider<ArchiveTodayOptions> {
 
       const wanted = resolveRequestedTimestamp(options.timestamp);
       const mementos = await this.fetchMementos(target, options);
-      const captures = mementos.map((page) => ({
-        url: page.url,
-        snapshot: page.snapshot,
-        timestamp: (page._meta as ArchiveTodayMetadata).hash,
-      }));
-      const capture = selectCapture(
-        preferSameUrl(captures, page, (candidate) => candidate.url),
-        wanted,
-      );
-      if (!capture) {
-        return createContentErrorResponse(
-          `No Archive.today capture for ${target}${wanted ? ` near ${wanted}` : ""}`,
-          "archive-today",
-          { requestedTimestamp: wanted || undefined },
-        );
-      }
+      const capture = selectArchiveTodayCapture(mementos, page, wanted);
+      if (!capture) return missingCaptureResponse(target, wanted);
 
       const snapshotUrl = new URL(capture.snapshot);
       const body = await fetchBody(
@@ -152,10 +214,15 @@ export class ArchiveTodayProvider extends BaseProvider<ArchiveTodayOptions> {
    * `first last memento`, so the match takes any first/last qualifiers;
    * requiring a bare `memento` would drop the newest capture from every
    * listing.
+
+   *
+   * @param target - Target.
+   * @param options - Options.
+   * @returns {Promise<ArchivedPage[]>} A promise resolving to the operation result.
    */
   private async fetchMementos(
     target: string,
-    options: ArchiveTodayOptions & ArchiveContentOptions,
+    options: Readonly<ArchiveTodayOptions & ArchiveContentOptions>,
   ): Promise<ArchivedPage[]> {
     const baseURL = "https://archive.is";
     // Memento timemap: https://archive.is/timemap/http://example.com
@@ -180,46 +247,10 @@ export class ArchiveTodayProvider extends BaseProvider<ArchiveTodayOptions> {
     let index = 0;
 
     while ((mementoMatch = mementoRegex.exec(timemapResponse)) !== null) {
-      const [, snapshotUrl, timestamp, origUrl, datetime] = mementoMatch;
-
-      if (origUrl.includes(target)) {
-        try {
-          // The snapshot URL carries the capture stamp too, so a datetime the
-          // regex matched but `Date` cannot read falls back to those digits.
-          // Fabricating the current time instead would sort the capture above
-          // every real one in a merged, newest-first response, and the cache
-          // would then repeat that answer for days.
-          const parsedDate = new Date(datetime);
-          const isoTimestamp = Number.isNaN(parsedDate.getTime())
-            ? waybackTimestampToISO(timestamp)
-            : parsedDate.toISOString();
-          if (!isoTimestamp) {
-            consola.debug("[archive-today] Dropping memento with unreadable capture time", {
-              datetime,
-              snapshot: snapshotUrl,
-            });
-            continue;
-          }
-          const cleanedUrl = withoutTrailingSlash(
-            cleanDoubleSlashes(origUrl.includes("://") ? origUrl : `https://${origUrl}`),
-          );
-          const cleanedSnapshotUrl = withoutTrailingSlash(snapshotUrl);
-
-          pages.push({
-            url: cleanedUrl,
-            timestamp: isoTimestamp,
-            snapshot: cleanedSnapshotUrl,
-            _meta: {
-              hash: timestamp,
-              raw_date: datetime,
-              position: index,
-            } as ArchiveTodayMetadata,
-          });
-
-          index++;
-        } catch (error) {
-          consola.error("Error parsing archive.today snapshot:", error);
-        }
+      const page = archiveTodayPage(mementoMatch, target, index);
+      if (page) {
+        pages.push(page);
+        index++;
       }
     }
 
@@ -227,6 +258,8 @@ export class ArchiveTodayProvider extends BaseProvider<ArchiveTodayOptions> {
   }
 }
 
-export default function archiveToday(initOptions: ArchiveTodayOptions = {}): ArchiveTodayProvider {
+export default function archiveToday(
+  initOptions: Readonly<ArchiveTodayOptions> = {},
+): ArchiveTodayProvider {
   return new ArchiveTodayProvider(initOptions);
 }

--- a/src/providers/base-provider.ts
+++ b/src/providers/base-provider.ts
@@ -23,7 +23,7 @@ export abstract class BaseProvider<
 > implements ArchiveProvider {
   abstract readonly name: string;
   abstract readonly slug?: string;
-  cacheKey(_options?: ArchiveOptions): string | undefined {
+  cacheKey(_options?: Readonly<ArchiveOptions>): string | undefined {
     return undefined;
   }
 
@@ -43,14 +43,19 @@ export abstract class BaseProvider<
     return mergeOptions<TOptions>(this.options, reqOptions);
   }
 
-  /** Same cascade as {@link resolveOptions}, keeping the content-only options typed. */
+  /**
+   * Same cascade as {@link resolveOptions}, keeping the content-only options typed.
+   *
+   * @param reqOptions - Req Options.
+   * @returns {Promise<TOptions & ArchiveContentOptions>} A promise resolving to the operation result.
+   */
   protected resolveContentOptions(
-    reqOptions: Partial<TOptions> & ArchiveContentOptions = {},
+    reqOptions?: Readonly<Partial<TOptions & ArchiveContentOptions>>,
   ): Promise<TOptions & ArchiveContentOptions> {
-    return mergeOptions<TOptions & ArchiveContentOptions>(this.options, reqOptions);
+    return mergeOptions<TOptions & ArchiveContentOptions>(this.options, reqOptions ?? {});
   }
 
-  abstract snapshots(domain: string, options?: ArchiveOptions): Promise<ArchiveResponse>;
+  abstract snapshots(domain: string, options?: Readonly<ArchiveOptions>): Promise<ArchiveResponse>;
 
-  content?(url: string, options?: ArchiveContentOptions): Promise<ArchiveContentResponse>;
+  content?(url: string, options?: Readonly<ArchiveContentOptions>): Promise<ArchiveContentResponse>;
 }

--- a/src/providers/commoncrawl.ts
+++ b/src/providers/commoncrawl.ts
@@ -58,6 +58,223 @@ interface CrawlCapture {
   length: string;
 }
 
+interface CrawlIndex {
+  collectionName: string;
+  indexName: string;
+}
+
+interface CrawlRecordBody {
+  text: string;
+  bytes: number;
+  truncated: boolean;
+  status?: number;
+  mime?: string;
+}
+
+interface CollinfoEntry {
+  name?: string;
+  "cdx-api"?: string;
+  cdxApi?: string;
+}
+
+function indexName(collection: string): string {
+  return collection.endsWith("-index") ? collection : `${collection}-index`;
+}
+
+function listingQuery(
+  domain: string,
+  options: Readonly<CommonCrawlOptions>,
+): Record<string, string> {
+  return {
+    url: normalizeDomain(domain),
+    output: "json",
+    fl: "url,timestamp,status,mime,length,offset,filename,digest",
+    collapse: "digest",
+    limit: String(options.limit ?? 1000),
+  };
+}
+
+function listingPage(
+  record: Readonly<Record<string, string>>,
+  collection: string,
+): ArchivedPage | undefined {
+  const isoTimestamp = waybackTimestampToISO(record["timestamp"] ?? "");
+  if (!isoTimestamp) {
+    consola.debug("[commoncrawl] Dropping record with invalid timestamp", {
+      timestamp: record["timestamp"],
+      url: record["url"],
+    });
+    return undefined;
+  }
+  const filename = record["filename"] ?? "";
+  return {
+    url: cleanDoubleSlashes(record["url"] ?? ""),
+    timestamp: isoTimestamp,
+    snapshot: `${DATA_BASE_URL}/${filename}`,
+    _meta: {
+      timestamp: record["timestamp"],
+      status: Number.parseInt(record["status"] || "0", 10),
+      digest: record["digest"],
+      mime: record["mime"],
+      length: record["length"],
+      offset: record["offset"],
+      filename,
+      collection,
+      provider: "commoncrawl",
+    } as CommonCrawlMetadata,
+  };
+}
+
+function contentQuery(target: string, wanted: string): Record<string, string> {
+  const params: Record<string, string> = {
+    url: target,
+    output: "json",
+    fl: "url,timestamp,status,mime,length,offset,filename,digest",
+    limit: String(CONTENT_CAPTURE_LIMIT),
+  };
+  if (wanted) {
+    params.closest = timestampUpperBound(wanted);
+    params.sort = "closest";
+  } else {
+    params.sort = "reverse";
+  }
+  return params;
+}
+
+function optionalCaptureFields(record: Readonly<Record<string, string>>): Partial<CrawlCapture> {
+  const result: Partial<CrawlCapture> = {};
+  const status = Number.parseInt(record["status"] ?? "", 10);
+  if (Number.isFinite(status)) result.status = status;
+  if (record["mime"]) result.mime = record["mime"];
+  if (record["digest"]) result.digest = record["digest"];
+  return result;
+}
+
+function crawlCapture(
+  record: Readonly<Record<string, string>>,
+  target: string,
+): CrawlCapture | undefined {
+  const timestamp = toWaybackTimestamp(record["timestamp"] ?? "");
+  const filename = record["filename"];
+  const offset = record["offset"];
+  const length = record["length"];
+  if (!timestamp || !filename || !offset || !length) return undefined;
+
+  return {
+    url: record["url"] ?? target,
+    timestamp,
+    filename,
+    offset,
+    length,
+    ...optionalCaptureFields(record),
+  };
+}
+
+function normalizeCdxApi(value: string): string {
+  const path = value.startsWith("http") ? new URL(value).pathname : value;
+  return path.startsWith("/") ? path.slice(1) : path;
+}
+
+function collinfoApi(entry: Readonly<CollinfoEntry>): string | undefined {
+  const primary = entry["cdx-api"];
+  return typeof primary === "string" && primary ? primary : entry.cdxApi;
+}
+
+function parseCollinfo(value: unknown): CrawlIndex | undefined {
+  if (!Array.isArray(value) || value.length === 0) return undefined;
+  const first: unknown = value[0];
+  if (typeof first !== "object" || first === null) return undefined;
+  const entry = first as CollinfoEntry;
+  const api = collinfoApi(entry);
+  if (typeof api === "string") {
+    const path = normalizeCdxApi(api);
+    const collectionName = path.endsWith("-index") ? path.slice(0, -"-index".length) : path;
+    return { collectionName, indexName: path };
+  }
+  if (typeof entry.name !== "string") return undefined;
+  return { collectionName: entry.name, indexName: indexName(entry.name) };
+}
+
+function commonCrawlContentResponse(
+  capture: Readonly<CrawlCapture>,
+  record: Readonly<CrawlRecordBody>,
+  collection: string,
+  wanted: string,
+): ArchiveContentResponse {
+  const mime = record.mime ?? capture.mime;
+  return createContentResponse(
+    {
+      url: cleanDoubleSlashes(capture.url),
+      timestamp: waybackTimestampToISO(capture.timestamp),
+      snapshot: `${DATA_BASE_URL}/${capture.filename}`,
+      content: record.text,
+      ...(mime ? { mime } : {}),
+      bytes: record.bytes,
+      truncated: record.truncated,
+      _meta: {
+        timestamp: capture.timestamp,
+        status: record.status ?? capture.status,
+        provider: "commoncrawl",
+        collection,
+        filename: capture.filename,
+        offset: capture.offset,
+        length: capture.length,
+        ...(capture.digest ? { digest: capture.digest } : {}),
+      },
+    },
+    "commoncrawl",
+    { collection, requestedTimestamp: wanted || undefined },
+  );
+}
+
+async function fetchIndexRecords(
+  path: string,
+  params: Readonly<Record<string, string>>,
+  options: Readonly<ArchiveOptions>,
+): Promise<{ records: Array<Record<string, string>>; queryParams: unknown }> {
+  const fetchOptions = await createFetchOptions(BASE_URL, params, {
+    retries: options.retries,
+    signal: options.signal,
+    timeout: options.timeout ?? 60_000,
+    responseType: "text",
+  });
+  try {
+    const raw: unknown = await $fetch(`/${path}`, fetchOptions);
+    return { records: parseIndexRecords(raw), queryParams: fetchOptions.params };
+  } catch (error) {
+    if (!isNoCapturesError(error)) throw error;
+    return { records: [], queryParams: fetchOptions.params };
+  }
+}
+
+function decodedCrawlRecord(
+  bytes: Uint8Array,
+  decodedTruncated: boolean,
+  recordTruncated: boolean,
+  maxBytes: number,
+  status: number | undefined,
+  contentType: string | undefined,
+): CrawlRecordBody {
+  const overflowed = bytes.byteLength > maxBytes;
+  const body = overflowed ? bytes.subarray(0, maxBytes) : bytes;
+  return {
+    text: decodeArchivedBody(body, contentType),
+    bytes: body.byteLength,
+    truncated: recordTruncated || decodedTruncated || overflowed,
+    ...(status === undefined ? {} : { status }),
+    ...(contentType ? { mime: contentType.split(";")[0]?.trim().toLowerCase() } : {}),
+  };
+}
+
+function parseByteRange(capture: Readonly<CrawlCapture>): { start: number; length: number } {
+  const start = Number.parseInt(capture.offset, 10);
+  const length = Number.parseInt(capture.length, 10);
+  if (!Number.isFinite(start) || !Number.isFinite(length) || length <= 0) {
+    throw new Error("Common Crawl index gave no usable byte range for this capture");
+  }
+  return { start, length };
+}
+
 /**
  * Common Crawl archive provider.
  */
@@ -67,8 +284,12 @@ export class CommonCrawlProvider extends BaseProvider<CommonCrawlOptions> {
 
   /**
    * Cache key extension that separates storage entries by collection.
+
+   *
+   * @param options - Options.
+   * @returns {string | undefined} The operation result.
    */
-  override cacheKey(options?: ArchiveOptions): string | undefined {
+  override cacheKey(options?: Readonly<ArchiveOptions>): string | undefined {
     const collection =
       (options as Partial<CommonCrawlOptions> | undefined)?.collection ?? this.options.collection;
     return collection === undefined ? undefined : `collection=${encodeURIComponent(collection)}`;
@@ -76,85 +297,37 @@ export class CommonCrawlProvider extends BaseProvider<CommonCrawlOptions> {
 
   /**
    * Fetch archived snapshots from Common Crawl.
+
+   *
+   * @param domain - Domain.
+   * @param reqOptions - Req Options.
+   * @returns {Promise<ArchiveResponse>} A promise resolving to the operation result.
    */
   async snapshots(
     domain: string,
-    reqOptions: Partial<CommonCrawlOptions> = {},
+    reqOptions: Readonly<Partial<CommonCrawlOptions>> = {},
   ): Promise<ArchiveResponse> {
     let collectionName: string | undefined;
 
     try {
       const options = await this.resolveOptions(reqOptions);
       const index = await this.resolveIndex(options);
-      collectionName = index.collectionName;
+      const collection = index.collectionName;
+      collectionName = collection;
 
-      const urlPattern = normalizeDomain(domain);
-      const params: Record<string, string> = {
-        url: urlPattern,
-        output: "json",
-        fl: "url,timestamp,status,mime,length,offset,filename,digest",
-        collapse: "digest",
-        limit: String(options.limit ?? 1000),
-      };
-
-      const fetchOptions = await createFetchOptions(BASE_URL, params, {
-        retries: options.retries,
-        signal: options.signal,
-        timeout: options.timeout ?? 60_000,
-        responseType: "text",
-      });
-      let raw: unknown;
-      try {
-        raw = await $fetch(`/${index.indexName}`, fetchOptions);
-      } catch (error) {
-        if (!isNoCapturesError(error)) throw error;
-        raw = "";
-      }
-      const records = parseIndexRecords(raw);
-
-      if (records.length === 0) {
-        return createSuccessResponse([], "commoncrawl", {
-          collection: collectionName,
-          queryParams: fetchOptions.params,
-        });
-      }
-
-      const pages: ArchivedPage[] = [];
-
-      for (const record of records) {
-        const isoTimestamp = waybackTimestampToISO(record.timestamp || "");
-        if (!isoTimestamp) {
-          consola.debug("[commoncrawl] Dropping record with invalid timestamp", {
-            timestamp: record.timestamp,
-            url: record.url,
-          });
-          continue;
-        }
-
-        const cleanedUrl = cleanDoubleSlashes(record.url || "");
-        const snapUrl = `${DATA_BASE_URL}/${record.filename}`;
-        pages.push({
-          url: cleanedUrl,
-          timestamp: isoTimestamp,
-          snapshot: snapUrl,
-          _meta: {
-            timestamp: record.timestamp,
-            status: Number.parseInt(record.status || "0", 10),
-            digest: record.digest,
-            mime: record.mime,
-            length: record.length,
-            offset: record.offset,
-            filename: record.filename,
-            collection: collectionName,
-            provider: "commoncrawl",
-          } as CommonCrawlMetadata,
-        });
-      }
+      const { records, queryParams } = await fetchIndexRecords(
+        index.indexName,
+        listingQuery(domain, options),
+        options,
+      );
+      const pages = records
+        .map((record) => listingPage(record, collection))
+        .filter((page): page is ArchivedPage => page !== undefined);
 
       return createSuccessResponse(pages, "commoncrawl", {
-        collection: collectionName,
+        collection,
         count: pages.length,
-        queryParams: fetchOptions.params,
+        queryParams,
       });
     } catch (error) {
       return createErrorResponse(error, "commoncrawl", { collection: collectionName });
@@ -167,10 +340,15 @@ export class CommonCrawlProvider extends BaseProvider<CommonCrawlOptions> {
    * Common Crawl has no playback host: the index gives the WARC file plus the
    * byte range of the record inside it, so the body is a range request against
    * that file, gzip-decoded, with the WARC and HTTP header blocks stripped off.
+
+   *
+   * @param url - Url.
+   * @param reqOptions - Req Options.
+   * @returns {Promise<ArchiveContentResponse>} A promise resolving to the operation result.
    */
   override async content(
     url: string,
-    reqOptions: Partial<CommonCrawlOptions> & ArchiveContentOptions = {},
+    reqOptions: Readonly<Partial<CommonCrawlOptions> & ArchiveContentOptions> = {},
   ): Promise<ArchiveContentResponse> {
     let collectionName: string | undefined;
 
@@ -198,33 +376,8 @@ export class CommonCrawlProvider extends BaseProvider<CommonCrawlOptions> {
         );
       }
 
-      const maxBytes = resolveMaxBytes(options);
-      const record = await this.readRecord(capture, options, maxBytes);
-      const mime = record.mime ?? capture.mime;
-
-      return createContentResponse(
-        {
-          url: cleanDoubleSlashes(capture.url),
-          timestamp: waybackTimestampToISO(capture.timestamp),
-          snapshot: `${DATA_BASE_URL}/${capture.filename}`,
-          content: record.text,
-          ...(mime ? { mime } : {}),
-          bytes: record.bytes,
-          truncated: record.truncated,
-          _meta: {
-            timestamp: capture.timestamp,
-            status: record.status ?? capture.status,
-            provider: "commoncrawl",
-            collection: collectionName,
-            filename: capture.filename,
-            offset: capture.offset,
-            length: capture.length,
-            ...(capture.digest ? { digest: capture.digest } : {}),
-          },
-        },
-        "commoncrawl",
-        { collection: collectionName, requestedTimestamp: wanted || undefined },
-      );
+      const record = await this.readRecord(capture, options, resolveMaxBytes(options));
+      return commonCrawlContentResponse(capture, record, collectionName, wanted);
     } catch (error) {
       return createContentErrorResponse(error, "commoncrawl", { collection: collectionName });
     }
@@ -237,22 +390,29 @@ export class CommonCrawlProvider extends BaseProvider<CommonCrawlOptions> {
    * The endpoint names differ from the collection ids by an `-index` suffix, and
    * the two are reported separately because the collection id is what a caller
    * sees in the response while the endpoint name is what the query needs.
+
+   *
+   * @param options - Options.
+   * @returns {Promise<{ collectionName: string; indexName: string }>} A promise resolving to the operation result.
    */
-  private async resolveIndex(
-    options: Partial<CommonCrawlOptions>,
-  ): Promise<{ collectionName: string; indexName: string }> {
-    let collectionName = options.collection as string | undefined;
-
-    if (collectionName && collectionName !== "CC-MAIN-latest") {
-      return {
-        collectionName,
-        indexName: collectionName.endsWith("-index") ? collectionName : `${collectionName}-index`,
-      };
+  private async resolveIndex(options: Readonly<Partial<CommonCrawlOptions>>): Promise<CrawlIndex> {
+    const configured = options.collection;
+    if (configured && configured !== "CC-MAIN-latest") {
+      return { collectionName: configured, indexName: indexName(configured) };
     }
+    return (
+      (await this.fetchLatestIndex(options)) ?? {
+        collectionName: "CC-MAIN-latest",
+        indexName: indexName("CC-MAIN-latest"),
+      }
+    );
+  }
 
-    let apiPath: string | undefined;
+  private async fetchLatestIndex(
+    options: Readonly<Partial<CommonCrawlOptions>>,
+  ): Promise<CrawlIndex | undefined> {
     try {
-      const collinfoOpts = await createFetchOptions(
+      const fetchOptions = await createFetchOptions(
         BASE_URL,
         {},
         {
@@ -261,114 +421,56 @@ export class CommonCrawlProvider extends BaseProvider<CommonCrawlOptions> {
           timeout: options.timeout ?? 60_000,
         },
       );
-      interface CollinfoEntry {
-        name?: string;
-        "cdx-api"?: string;
-        cdxApi?: string;
-      }
-      const collinfo = (await $fetch("/collinfo.json", collinfoOpts)) as CollinfoEntry[];
-      if (Array.isArray(collinfo) && collinfo.length > 0) {
-        const first = collinfo[0];
-        const cdxApiProp = first["cdx-api"] || first.cdxApi;
-        if (typeof cdxApiProp === "string") {
-          let raw = cdxApiProp.startsWith("http") ? new URL(cdxApiProp).pathname : cdxApiProp;
-          raw = raw.startsWith("/") ? raw.slice(1) : raw;
-          apiPath = raw;
-          collectionName = raw.endsWith("-index") ? raw.slice(0, -"-index".length) : raw;
-        } else if (typeof first.name === "string") {
-          collectionName = first.name;
-          apiPath = collectionName.endsWith("-index") ? collectionName : `${collectionName}-index`;
-        }
-      }
-    } catch (collinfoError) {
-      consola.debug("[commoncrawl] collinfo.json fetch failed, using fallback:", collinfoError);
+      const response: unknown = await $fetch("/collinfo.json", fetchOptions);
+      return parseCollinfo(response);
+    } catch (error) {
+      consola.debug("[commoncrawl] collinfo.json fetch failed, using fallback:", error);
+      return undefined;
     }
-
-    if (!collectionName) collectionName = "CC-MAIN-latest";
-    if (!apiPath) {
-      apiPath = collectionName.endsWith("-index") ? collectionName : `${collectionName}-index`;
-    }
-
-    return { collectionName, indexName: apiPath };
   }
 
-  /** Lists the indexed captures of one exact URL, with their WARC coordinates. */
+  /**
+   * Lists the indexed captures of one exact URL, with their WARC coordinates.
+   * The row cap leaves enough captures to sort frequently crawled URLs before selection.
+   *
+   * @param indexName - Index Name.
+   * @param target - Target.
+   * @param wanted - Wanted.
+   * @param options - Options.
+   * @returns {Promise<CrawlCapture[]>} A promise resolving to the operation result.
+   */
   private async findCaptures(
     indexName: string,
     target: string,
     wanted: string,
-    options: ArchiveContentOptions,
+    options: Readonly<ArchiveContentOptions>,
   ): Promise<CrawlCapture[]> {
-    const params: Record<string, string> = {
-      url: target,
-      output: "json",
-      fl: "url,timestamp,status,mime,length,offset,filename,digest",
-      limit: String(CONTENT_CAPTURE_LIMIT),
-    };
-
-    // The row cap is what makes this matter: a URL crawled more often than the
-    // cap would otherwise be answered from an arbitrary slice of its captures.
-    // Both parameters are the index's own, and a deployment that ignores them
-    // leaves the choice where it already is, in `selectCapture`.
-    if (wanted) {
-      params.closest = timestampUpperBound(wanted);
-      params.sort = "closest";
-    } else {
-      params.sort = "reverse";
-    }
-
-    const fetchOptions = await createFetchOptions(BASE_URL, params, {
-      retries: options.retries,
-      signal: options.signal,
-      timeout: options.timeout ?? 60_000,
-      responseType: "text",
-    });
-    let raw: unknown;
-    try {
-      raw = await $fetch(`/${indexName}`, fetchOptions);
-    } catch (error) {
-      if (!isNoCapturesError(error)) throw error;
-      raw = "";
-    }
-
-    const captures: CrawlCapture[] = [];
-    for (const record of parseIndexRecords(raw)) {
-      const timestamp = toWaybackTimestamp(record.timestamp ?? "");
-      if (!timestamp || !record.filename || !record.offset || !record.length) continue;
-
-      const status = Number.parseInt(record.status ?? "", 10);
-      captures.push({
-        url: record.url ?? target,
-        timestamp,
-        filename: record.filename,
-        offset: record.offset,
-        length: record.length,
-        ...(Number.isFinite(status) ? { status } : {}),
-        ...(record.mime ? { mime: record.mime } : {}),
-        ...(record.digest ? { digest: record.digest } : {}),
-      });
-    }
-
-    return captures;
+    const { records } = await fetchIndexRecords(indexName, contentQuery(target, wanted), options);
+    return records
+      .map((record) => crawlCapture(record, target))
+      .filter((capture): capture is CrawlCapture => capture !== undefined);
   }
 
-  /** Fetches one WARC record by byte range and unwraps the HTTP response inside it. */
-  private async readRecord(
-    capture: CrawlCapture,
-    options: ArchiveContentOptions,
-    maxBytes: number,
-  ): Promise<{
+  /**
+   * Fetches one WARC record by byte range and unwraps the HTTP response inside it.
+   *
+   * @param capture - Capture.
+   * @param options - Options.
+   * @param maxBytes - Max Bytes.
+   * @returns {Promise<{
     text: string;
     bytes: number;
     truncated: boolean;
     status?: number;
     mime?: string;
-  }> {
-    const start = Number.parseInt(capture.offset, 10);
-    const length = Number.parseInt(capture.length, 10);
-    if (!Number.isFinite(start) || !Number.isFinite(length) || length <= 0) {
-      throw new Error("Common Crawl index gave no usable byte range for this capture");
-    }
+  }>} A promise resolving to the operation result.
+   */
+  private async readRecord(
+    capture: Readonly<CrawlCapture>,
+    options: Readonly<ArchiveContentOptions>,
+    maxBytes: number,
+  ): Promise<CrawlRecordBody> {
+    const { start, length } = parseByteRange(capture);
 
     const fetchOptions = await createFetchOptions(
       DATA_BASE_URL,
@@ -381,7 +483,7 @@ export class CommonCrawlProvider extends BaseProvider<CommonCrawlOptions> {
         headers: { range: `bytes=${start}-${start + length - 1}` },
       },
     );
-    const segment = await $fetch(`/${capture.filename}`, fetchOptions);
+    const segment: unknown = await $fetch(`/${capture.filename}`, fetchOptions);
 
     // The record's own headers sit in front of the body, so the decompression
     // cap has to leave room for them or a small body would come back empty.
@@ -403,21 +505,18 @@ export class CommonCrawlProvider extends BaseProvider<CommonCrawlOptions> {
       : parts.body;
 
     const decoded = await decodeContentEncoding(framed, contentEncoding, maxBytes);
-
-    const overflowed = decoded.bytes.byteLength > maxBytes;
-    const body = overflowed ? decoded.bytes.subarray(0, maxBytes) : decoded.bytes;
-
-    return {
-      text: decodeArchivedBody(body, contentType),
-      bytes: body.byteLength,
-      truncated: record.truncated || decoded.truncated || overflowed,
-      ...(status === undefined ? {} : { status }),
-      ...(contentType ? { mime: contentType.split(";")[0]?.trim().toLowerCase() } : {}),
-    };
+    return decodedCrawlRecord(
+      decoded.bytes,
+      decoded.truncated,
+      record.truncated,
+      maxBytes,
+      status,
+      contentType,
+    );
   }
 }
 
-/**
+/*
  * Whether a thrown index error is the CDX way of saying the URL was never
  * captured: the endpoint answers 404 with a JSON `No Captures found` message
  * instead of an empty body, so a missing page would otherwise read as an
@@ -435,22 +534,31 @@ function isNoCapturesError(error: unknown): boolean {
   return body.includes("No Captures found");
 }
 
-/** Parses the newline-delimited JSON the CDX index answers with. */
+/* Parses the newline-delimited JSON the CDX index answers with. */
+function parseIndexRecord(line: string): Record<string, string> {
+  const parsed: unknown = JSON.parse(line);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new TypeError("Common Crawl index returned a non-object JSON record");
+  }
+  const record: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    if (typeof value === "string") record[key] = value;
+  }
+  return record;
+}
+
 function parseIndexRecords(raw: unknown): Array<Record<string, string>> {
   const text = typeof raw === "string" ? raw : String(raw);
   const records: Array<Record<string, string>> = [];
-
   for (const line of text.split("\n")) {
     const trimmed = line.trim();
-    if (!trimmed) continue;
-    records.push(JSON.parse(trimmed) as Record<string, string>);
+    if (trimmed) records.push(parseIndexRecord(trimmed));
   }
-
   return records;
 }
 
 export default function commonCrawl(
-  initOptions: Partial<CommonCrawlOptions> = {},
+  initOptions: Readonly<Partial<CommonCrawlOptions>> = {},
 ): CommonCrawlProvider {
   return new CommonCrawlProvider(initOptions);
 }

--- a/src/providers/conifer.ts
+++ b/src/providers/conifer.ts
@@ -22,6 +22,52 @@ interface ConiferSearchResponse {
   results?: ConiferResult[];
 }
 
+interface ConiferRequest {
+  user: string;
+  collection: string;
+  query: string;
+  limit: number;
+}
+
+function resolveConiferRequest(domain: string, options: Readonly<ConiferOptions>): ConiferRequest {
+  const user = String(options.user).trim();
+  const collection = String(options.collection).trim();
+  if (!user || !collection) throw new Error("Conifer user and collection are required");
+
+  const query = normalizeDomain(domain, false).trim();
+  if (!query) throw new Error("Conifer target must not be empty");
+
+  return { user, collection, query, limit: Math.max(0, Math.trunc(options.limit ?? 1000)) };
+}
+
+function mapConiferResults(
+  results: readonly Readonly<ConiferResult>[],
+  request: Readonly<ConiferRequest>,
+  baseUrl: string,
+): ArchivedPage[] {
+  const pages: ArchivedPage[] = [];
+  for (const result of results) {
+    if (pages.length >= request.limit) break;
+    if (!result.url || !result.timestamp) continue;
+
+    const timestamp = waybackTimestampToISO(result.timestamp);
+    if (!timestamp) continue;
+    pages.push({
+      url: result.url,
+      timestamp,
+      snapshot: `${baseUrl}/${encodeURIComponent(request.user)}/${encodeURIComponent(request.collection)}/${result.timestamp}/${result.url}`,
+      _meta: {
+        provider: "conifer",
+        timestamp: result.timestamp,
+        id: result.id,
+        recording: result.rec,
+        title: result.title,
+      },
+    });
+  }
+  return pages;
+}
+
 /**
  * Read-only access to pages in an existing public Conifer collection.
  */
@@ -29,11 +75,11 @@ export class ConiferProvider extends BaseProvider<ConiferOptions> {
   readonly name = "Conifer";
   readonly slug = "conifer";
 
-  constructor(options: ConiferOptions) {
+  constructor(options: Readonly<ConiferOptions>) {
     super(options);
   }
 
-  override cacheKey(options?: ArchiveOptions): string {
+  override cacheKey(options?: Readonly<ArchiveOptions>): string {
     const requestOptions = options as Partial<ConiferOptions> | undefined;
     const user = String(requestOptions?.user ?? this.options.user).trim();
     const collection = String(requestOptions?.collection ?? this.options.collection).trim();
@@ -50,34 +96,16 @@ export class ConiferProvider extends BaseProvider<ConiferOptions> {
 
   async snapshots(
     domain: string,
-    reqOptions: Partial<ConiferOptions> = {},
+    reqOptions: Readonly<Partial<ConiferOptions>> = {},
   ): Promise<ArchiveResponse> {
     try {
       const options = await this.resolveOptions(reqOptions);
-      const user = String(options.user).trim();
-      const collection = String(options.collection).trim();
-      if (!user || !collection) {
-        throw new Error("Conifer user and collection are required");
-      }
-
-      const query = normalizeDomain(domain, false).trim();
-      if (!query) {
-        throw new Error("Conifer target must not be empty");
-      }
-
+      const request = resolveConiferRequest(domain, options);
+      const { collection, limit, query, user } = request;
       const baseUrl = "https://conifer.rhizome.org";
-      const params = {
-        user,
-        coll: collection,
-        url: query,
-      };
-      const limit = Math.max(0, Math.trunc(options.limit ?? 1000));
+      const params = { user, coll: collection, url: query };
       if (limit === 0) {
-        return createSuccessResponse([], "conifer", {
-          user,
-          collection,
-          queryParams: params,
-        });
+        return createSuccessResponse([], "conifer", { user, collection, queryParams: params });
       }
       const fetchOptions = await createFetchOptions(baseUrl, params, {
         retries: options.retries,
@@ -89,33 +117,11 @@ export class ConiferProvider extends BaseProvider<ConiferOptions> {
         responseType: "json",
       });
 
-      const pages: ArchivedPage[] = [];
-
-      for (const result of response.results ?? []) {
-        if (pages.length >= limit) break;
-        if (!result.url || !result.timestamp) continue;
-
-        const timestamp = waybackTimestampToISO(result.timestamp);
-        if (!timestamp) continue;
-
-        pages.push({
-          url: result.url,
-          timestamp,
-          snapshot: `${baseUrl}/${encodeURIComponent(user)}/${encodeURIComponent(collection)}/${result.timestamp}/${result.url}`,
-          _meta: {
-            provider: "conifer",
-            timestamp: result.timestamp,
-            id: result.id,
-            recording: result.rec,
-            title: result.title,
-          },
-        });
-      }
-
+      const pages = mapConiferResults(response.results ?? [], request, baseUrl);
       return createSuccessResponse(pages, "conifer", {
         user,
         collection,
-        queryParams: fetchOptions.params || {},
+        queryParams: fetchOptions.params ?? {},
       });
     } catch (error) {
       return createErrorResponse(error, "conifer");
@@ -123,6 +129,6 @@ export class ConiferProvider extends BaseProvider<ConiferOptions> {
   }
 }
 
-export default function conifer(options: ConiferOptions): ConiferProvider {
+export default function conifer(options: Readonly<ConiferOptions>): ConiferProvider {
   return new ConiferProvider(options);
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -28,13 +28,13 @@ export const providers = {
   /**
    * Creates a Wayback Machine provider.
    * @param options - Configuration options for the Wayback Machine provider
-   * @returns The Wayback Machine provider
+   * @returns {Promise<ArchiveProvider>} The Wayback Machine provider
    * @example
    * ```js
    * const waybackProvider = providers.wayback({ limit: 100 })
    * ```
    */
-  async wayback(options?: WaybackOptions): Promise<ArchiveProvider> {
+  async wayback(options?: Readonly<WaybackOptions>): Promise<ArchiveProvider> {
     const { WaybackProvider } = await loadWaybackModule();
     return new WaybackProvider(options);
   },
@@ -42,13 +42,13 @@ export const providers = {
   /**
    * Creates an Archive-It provider for one collection.
    * @param options - Configuration including the required Archive-It collection ID
-   * @returns The Archive-It provider
+   * @returns {Promise<ArchiveProvider>} The Archive-It provider
    * @example
    * ```js
    * const archiveItProvider = providers.archiveIt({ collection: 4399 })
    * ```
    */
-  async archiveIt(options: ArchiveItOptions): Promise<ArchiveProvider> {
+  async archiveIt(options: Readonly<ArchiveItOptions>): Promise<ArchiveProvider> {
     const { ArchiveItProvider } = await loadArchiveItModule();
     return new ArchiveItProvider(options);
   },
@@ -56,13 +56,13 @@ export const providers = {
   /**
    * Creates a Conifer provider for one existing public collection.
    * @param options - Configuration including the required user and collection slugs
-   * @returns The Conifer provider
+   * @returns {Promise<ArchiveProvider>} The Conifer provider
    * @example
    * ```js
    * const coniferProvider = providers.conifer({ user: 'imamuseum', collection: 'imamuseumorg' })
    * ```
    */
-  async conifer(options: ConiferOptions): Promise<ArchiveProvider> {
+  async conifer(options: Readonly<ConiferOptions>): Promise<ArchiveProvider> {
     const { ConiferProvider } = await loadConiferModule();
     return new ConiferProvider(options);
   },
@@ -70,19 +70,24 @@ export const providers = {
   /**
    * Creates an Archive.today provider.
    * @param options - Configuration options for the Archive.today provider
-   * @returns The Archive.today provider
+   * @returns {Promise<ArchiveProvider>} The Archive.today provider
    * @example
    * ```js
    * const archiveTodayProvider = providers.archiveToday({ timeout: 15000 })
    * ```
    */
-  async archiveToday(options?: ArchiveTodayOptions): Promise<ArchiveProvider> {
+  async archiveToday(options?: Readonly<ArchiveTodayOptions>): Promise<ArchiveProvider> {
     const { ArchiveTodayProvider } = await loadArchiveTodayModule();
     return new ArchiveTodayProvider(options);
   },
 
-  /** Creates a lazily loaded Memento provider that uses MemGator. */
-  async memento(options?: MementoOptions): Promise<ArchiveProvider> {
+  /**
+   * Creates a lazily loaded Memento provider that uses MemGator.
+   *
+   * @param options - Options.
+   * @returns {Promise<ArchiveProvider>} A promise resolving to the operation result.
+   */
+  async memento(options?: Readonly<MementoOptions>): Promise<ArchiveProvider> {
     const { MementoProvider } = await loadMementoModule();
     return new MementoProvider(options);
   },
@@ -90,13 +95,13 @@ export const providers = {
   /**
    * Creates a Perma.cc provider.
    * @param options - Configuration options for the Perma.cc provider (requires apiKey)
-   * @returns The Perma.cc provider
+   * @returns {Promise<ArchiveProvider>} The Perma.cc provider
    * @example
    * ```js
    * const permaccProvider = providers.permacc({ apiKey: 'your-api-key' })
    * ```
    */
-  async permacc(options?: Partial<PermaccOptions>): Promise<ArchiveProvider> {
+  async permacc(options?: Readonly<Partial<PermaccOptions>>): Promise<ArchiveProvider> {
     const { PermaccProvider } = await loadPermaccModule();
     return new PermaccProvider(options);
   },
@@ -104,13 +109,13 @@ export const providers = {
   /**
    * Creates a Common Crawl provider.
    * @param options - Configuration options for the Common Crawl provider
-   * @returns The Common Crawl provider
+   * @returns {Promise<ArchiveProvider>} The Common Crawl provider
    * @example
    * ```js
    * const commoncrawlProvider = providers.commoncrawl({ collection: 'CC-MAIN-2023-50' })
    * ```
    */
-  async commoncrawl(options?: CommonCrawlOptions): Promise<ArchiveProvider> {
+  async commoncrawl(options?: Readonly<CommonCrawlOptions>): Promise<ArchiveProvider> {
     const { CommonCrawlProvider } = await loadCommonCrawlModule();
     return new CommonCrawlProvider(options);
   },
@@ -118,13 +123,13 @@ export const providers = {
   /**
    * Creates a WebCite provider.
    * @param options - Configuration options for the WebCite provider
-   * @returns The WebCite provider
+   * @returns {Promise<ArchiveProvider>} The WebCite provider
    * @example
    * ```js
    * const webciteProvider = providers.webcite({ timeout: 10000 })
    * ```
    */
-  async webcite(options?: WebCiteOptions): Promise<ArchiveProvider> {
+  async webcite(options?: Readonly<WebCiteOptions>): Promise<ArchiveProvider> {
     const { WebCiteProvider } = await loadWebCiteModule();
     return new WebCiteProvider(options);
   },
@@ -134,14 +139,14 @@ export const providers = {
    * Note: Archive-It is excluded because it requires a collection ID; Perma.cc requires an API key.
    * Memento is excluded because it already aggregates many of the same archives.
    * @param options - Common configuration options for all providers
-   * @returns An array of all common providers
+   * @returns {Promise<ArchiveProvider[]>} An array of all common providers
    * @example
    * ```js
    * const allProviders = providers.all({ timeout: 15000 })
    * const archive = createArchive(allProviders)
    * ```
    */
-  async all(options?: ArchiveOptions): Promise<ArchiveProvider[]> {
+  async all(options?: Readonly<ArchiveOptions>): Promise<ArchiveProvider[]> {
     return Promise.all([
       this.wayback(options),
       this.archiveToday(options),

--- a/src/providers/memento.ts
+++ b/src/providers/memento.ts
@@ -27,13 +27,47 @@ const DEFAULT_BASE_URL = "https://memgator.cs.odu.edu";
 const MAX_CAPTURE_CLOCK_SKEW_MS = 24 * 60 * 60 * 1000;
 
 interface JsonTimeMapMemento {
-  datetime: string;
-  uri: string;
+  readonly datetime: string;
+  readonly uri: string;
 }
 
 interface ParsedTimeMap {
-  originalUri: string;
-  mementos: JsonTimeMapMemento[];
+  readonly originalUri: string;
+  readonly mementos: readonly JsonTimeMapMemento[];
+}
+
+interface MementoCapturePage {
+  readonly url: string;
+  readonly timestamp: string;
+  readonly snapshot: string;
+}
+
+interface MementoCapture {
+  readonly page: MementoCapturePage;
+  readonly original: string;
+  readonly timestamp: string;
+}
+
+interface MementoPlayback {
+  readonly body: Readonly<FetchedBody> & { readonly capturedAt: string };
+  readonly baseURL: string;
+  readonly proxyFallback: boolean;
+}
+
+function selectMementoCapture(
+  pages: readonly ArchivedPage[],
+  target: string,
+  wanted: string | undefined,
+): MementoCapture | undefined {
+  const captures = pages.map((page) => ({
+    page,
+    original: page.url,
+    timestamp: toWaybackTimestamp(page.timestamp),
+  }));
+  return selectCapture(
+    preferSameUrl(captures, target, (candidate) => candidate.original),
+    wanted,
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -48,8 +82,15 @@ function isNotFound(error: unknown): boolean {
 function normalizedHostname(value: string): string {
   return value
     .toLowerCase()
-    .replace(/^\[|\]$/g, "")
+    .replaceAll(/^\[|\]$/g, "")
     .replace(/\.$/, "");
+}
+
+function ipv4Octets(hostname: string): readonly [number, number, number, number] | undefined {
+  const octets = hostname.split(".").map((part) => Number(part));
+  if (octets.length !== 4) return undefined;
+  if (octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return undefined;
+  return [octets[0], octets[1], octets[2], octets[3]];
 }
 
 function isLocalDevelopmentHostname(value: string): boolean {
@@ -57,50 +98,44 @@ function isLocalDevelopmentHostname(value: string): boolean {
   if (hostname === "localhost" || hostname.endsWith(".localhost") || hostname === "::1") {
     return true;
   }
-  const octets = hostname.split(".").map((part) => Number(part));
-  return (
-    octets.length === 4 &&
-    octets.every((part) => Number.isInteger(part) && part >= 0 && part <= 255) &&
-    octets[0] === 127
-  );
+  return ipv4Octets(hostname)?.[0] === 127;
+}
+
+const UNSAFE_FIRST_IPV4_OCTETS = new Set([0, 10, 127]);
+const UNSAFE_SECOND_IPV4_OCTETS: Readonly<Record<number, readonly number[]>> = {
+  169: [254],
+  192: [0, 168],
+  198: [18, 19],
+};
+
+function isUnsafeIpv6(hostname: string): boolean {
+  if (hostname === "::" || hostname === "::1" || hostname.startsWith("::ffff:")) return true;
+  return !/^[23][\da-f]{3}$/i.test(hostname.split(":", 1)[0]);
+}
+
+function inRange(value: number, minimum: number, maximum: number): boolean {
+  return value >= minimum && value <= maximum;
+}
+
+function isUnsafeIpv4(hostname: string): boolean {
+  const octets = ipv4Octets(hostname);
+  if (!octets) return false;
+  const [first, second] = octets;
+  if (UNSAFE_FIRST_IPV4_OCTETS.has(first) || first >= 224) return true;
+  if (first === 100) return inRange(second, 64, 127);
+  if (first === 172) return inRange(second, 16, 31);
+  return UNSAFE_SECOND_IPV4_OCTETS[first]?.includes(second) ?? false;
 }
 
 function isUnsafeHostname(value: string): boolean {
   const hostname = normalizedHostname(value);
-  if (
+  const reservedName =
     hostname === "localhost" ||
     hostname.endsWith(".localhost") ||
     hostname.endsWith(".local") ||
-    hostname.endsWith(".internal")
-  ) {
-    return true;
-  }
-
-  if (hostname.includes(":")) {
-    if (hostname === "::" || hostname === "::1" || hostname.startsWith("::ffff:")) return true;
-    const firstHextet = hostname.split(":", 1)[0];
-    return !/^[23][\da-f]{3}$/i.test(firstHextet);
-  }
-
-  const octets = hostname.split(".").map((part) => Number(part));
-  if (
-    octets.length !== 4 ||
-    octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)
-  ) {
-    return false;
-  }
-  const [first, second] = octets;
-  return (
-    first === 0 ||
-    first === 10 ||
-    first === 127 ||
-    (first === 100 && second >= 64 && second <= 127) ||
-    (first === 169 && second === 254) ||
-    (first === 172 && second >= 16 && second <= 31) ||
-    (first === 192 && (second === 0 || second === 168)) ||
-    (first === 198 && (second === 18 || second === 19)) ||
-    first >= 224
-  );
+    hostname.endsWith(".internal");
+  if (reservedName) return true;
+  return hostname.includes(":") ? isUnsafeIpv6(hostname) : isUnsafeIpv4(hostname);
 }
 
 function isSafeMementoURL(url: URL): boolean {
@@ -123,13 +158,153 @@ function assertSafePlaybackURL(url: URL, localOrigin?: string): void {
   }
 }
 
+function parseOriginalUri(value: unknown): URL {
+  if (typeof value !== "string") {
+    throw new TypeError("Memento aggregator returned a JSON TimeMap without original_uri");
+  }
+  let original: URL;
+  try {
+    original = new URL(value);
+  } catch {
+    throw new Error("Memento aggregator returned an invalid original_uri");
+  }
+  if (original.protocol !== "http:" && original.protocol !== "https:") {
+    throw new Error("Memento aggregator returned original_uri without HTTP or HTTPS");
+  }
+  if (original.username || original.password) {
+    throw new Error("Memento aggregator returned an original_uri containing credentials");
+  }
+  return original;
+}
+
+function parseMementoList(value: unknown): JsonTimeMapMemento[] {
+  if (!Array.isArray(value)) {
+    throw new TypeError("Memento aggregator returned a JSON TimeMap without a valid mementos.list");
+  }
+  const list: JsonTimeMapMemento[] = [];
+  for (const item of value) {
+    if (!isRecord(item)) continue;
+    const datetime = item["datetime"];
+    const uri = item["uri"];
+    if (typeof datetime === "string" && typeof uri === "string") list.push({ datetime, uri });
+  }
+  return list;
+}
+
+function pageFromMemento(
+  memento: Readonly<JsonTimeMapMemento>,
+  originalUri: string,
+  latestPossibleCapture: number,
+): ArchivedPage | undefined {
+  const stamp = toWaybackTimestamp(memento.datetime);
+  if (stamp.length !== 14) return undefined;
+  const timestamp = waybackTimestampToISO(stamp);
+  if (!timestamp || Date.parse(timestamp) > latestPossibleCapture) return undefined;
+
+  let snapshot: URL;
+  try {
+    snapshot = new URL(memento.uri);
+  } catch {
+    return undefined;
+  }
+  if (!isSafeMementoURL(snapshot)) return undefined;
+  return {
+    url: originalUri,
+    timestamp,
+    snapshot: snapshot.href,
+    _meta: {
+      provider: "memento",
+      archive: snapshot.hostname,
+      datetime: memento.datetime,
+    },
+  };
+}
+
+function playbackMetadata(playback: MementoPlayback): Record<string, unknown> {
+  const { baseURL, body, proxyFallback } = playback;
+  const metadata: Record<string, unknown> = {
+    provider: "memento",
+    status: body.status,
+    aggregator: baseURL,
+    rawSnapshot: body.url,
+  };
+  if (proxyFallback) metadata["proxyFallback"] = true;
+  else {
+    metadata["archive"] = new URL(body.url).hostname;
+    metadata["datetime"] = body.capturedAt;
+  }
+  return metadata;
+}
+
+function mementoContentResponse(
+  capture: Readonly<MementoCapture>,
+  playback: MementoPlayback,
+  wanted: string | undefined,
+): ArchiveContentResponse {
+  const { baseURL, body, proxyFallback } = playback;
+  const servedDifferent = body.capturedAt !== capture.page.timestamp;
+  return createContentResponse(
+    {
+      url: capture.page.url,
+      timestamp: body.capturedAt,
+      snapshot: proxyFallback || servedDifferent ? body.url : capture.page.snapshot,
+      content: body.text,
+      ...(body.mime ? { mime: body.mime } : {}),
+      bytes: body.bytes,
+      truncated: body.truncated,
+      _meta: playbackMetadata(playback),
+    },
+    "memento",
+    { requestedTimestamp: wanted || undefined, aggregator: baseURL },
+  );
+}
+
+function isAllowedAggregatorProtocol(parsed: URL, localDevelopment: boolean): boolean {
+  return parsed.protocol === "https:" || (parsed.protocol === "http:" && localDevelopment);
+}
+
+function hasAggregatorUrlExtras(parsed: URL): boolean {
+  return Boolean(parsed.username || parsed.password || parsed.search || parsed.hash);
+}
+
+function validateAggregatorUrl(parsed: URL): void {
+  const localDevelopment = isLocalDevelopmentHostname(parsed.hostname);
+  if (isUnsafeHostname(parsed.hostname) && !localDevelopment) {
+    throw new Error("Memento aggregator base URL must use a public host");
+  }
+  if (!isAllowedAggregatorProtocol(parsed, localDevelopment)) {
+    throw new Error("Memento aggregator base URL must use HTTPS (HTTP is allowed only locally)");
+  }
+  if (hasAggregatorUrlExtras(parsed)) {
+    throw new Error(
+      "Memento aggregator base URL cannot contain credentials, a query, or a fragment",
+    );
+  }
+}
+
+function parseAggregatorBaseUrl(raw: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error("Invalid Memento aggregator base URL");
+  }
+  validateAggregatorUrl(parsed);
+  return parsed.href.replace(/\/$/, "");
+}
+
 /** Memento JSON TimeMaps through ODU MemGator, replacing the discontinued Time Travel aggregator. */
 export class MementoProvider extends BaseProvider<MementoOptions> {
   readonly name = "Memento (MemGator)";
   readonly slug = "memento";
 
-  /** Separates aggregators and caps while redacting invalid URLs before cache lookup. */
-  override cacheKey(options?: MementoOptions): string {
+  /**
+   * Separates aggregators and caps while redacting invalid URLs before cache lookup.
+   *
+   * @param options - Options.
+   * @returns {string} The resulting string.
+   */
+  override cacheKey(options?: Readonly<MementoOptions>): string {
     const rawBaseURL = options?.baseUrl ?? this.options.baseUrl ?? DEFAULT_BASE_URL;
     let baseURL = rawBaseURL;
     try {
@@ -143,8 +318,17 @@ export class MementoProvider extends BaseProvider<MementoOptions> {
     return parts.join(":");
   }
 
-  /** Fetches the aggregated JSON TimeMap for one exact original URL. */
-  async snapshots(domain: string, reqOptions: MementoOptions = {}): Promise<ArchiveResponse> {
+  /**
+   * Fetches the aggregated JSON TimeMap for one exact original URL.
+   *
+   * @param domain - Domain.
+   * @param reqOptions - Req Options.
+   * @returns {Promise<ArchiveResponse>} A promise resolving to the operation result.
+   */
+  async snapshots(
+    domain: string,
+    reqOptions: Readonly<MementoOptions> = {},
+  ): Promise<ArchiveResponse> {
     let target: string | undefined;
     try {
       const options = await this.resolveOptions(reqOptions);
@@ -163,10 +347,16 @@ export class MementoProvider extends BaseProvider<MementoOptions> {
     }
   }
 
-  /** Reads the selected Memento URI directly, with negotiation through MemGator only as fallback. */
+  /**
+   * Reads the selected Memento URI directly, with negotiation through MemGator only as fallback.
+   *
+   * @param url - Url.
+   * @param reqOptions - Req Options.
+   * @returns {Promise<ArchiveContentResponse>} A promise resolving to the operation result.
+   */
   override async content(
     url: string,
-    reqOptions: Partial<MementoOptions> & ArchiveContentOptions = {},
+    reqOptions: Readonly<Partial<MementoOptions> & ArchiveContentOptions> = {},
   ): Promise<ArchiveContentResponse> {
     try {
       const options = await this.resolveContentOptions(reqOptions);
@@ -174,15 +364,7 @@ export class MementoProvider extends BaseProvider<MementoOptions> {
       const target = this.originalURL(unwrapped.url);
       const wanted = resolveRequestedTimestamp(options.timestamp ?? unwrapped.timestamp);
       const { pages } = await this.fetchTimeMap(target, options);
-      const captures = pages.map((page) => ({
-        page,
-        original: page.url,
-        timestamp: toWaybackTimestamp(page.timestamp),
-      }));
-      const capture = selectCapture(
-        preferSameUrl(captures, target, (candidate) => candidate.original),
-        wanted,
-      );
+      const capture = selectMementoCapture(pages, target, wanted);
       if (!capture) {
         return createContentErrorResponse(
           `No Memento capture for ${target}${wanted ? ` near ${wanted}` : ""}`,
@@ -191,69 +373,48 @@ export class MementoProvider extends BaseProvider<MementoOptions> {
         );
       }
 
-      const baseURL = this.baseURL(options);
-      const aggregator = new URL(baseURL);
-      const localAggregatorOrigin = isLocalDevelopmentHostname(aggregator.hostname)
-        ? aggregator.origin
-        : undefined;
-      let proxyFallback = false;
-      let body: FetchedBody;
-      try {
-        const snapshot = this.rawSnapshotURL(capture.page.snapshot);
-        body = await fetchBody(snapshot.origin, `${snapshot.pathname}${snapshot.search}`, options, {
-          assertURL: (candidate) => assertSafePlaybackURL(candidate),
-        });
-        if (!body.capturedAt) {
-          throw new Error("Direct Memento playback did not identify its capture time");
-        }
-      } catch {
-        proxyFallback = true;
-        body = await fetchBody(
-          baseURL,
-          `/memento/proxy/${capture.timestamp}/${encodeURIComponent(capture.page.url)}`,
-          options,
-          {
-            assertURL: (candidate) => assertSafePlaybackURL(candidate, localAggregatorOrigin),
-          },
-        );
-      }
-      if (!body.capturedAt) {
-        throw new Error("Memento playback response did not identify its capture time");
-      }
-      const servedDifferent = body.capturedAt !== capture.page.timestamp;
-      const archive = proxyFallback ? undefined : new URL(body.url).hostname;
-      const datetime = proxyFallback ? undefined : body.capturedAt;
-
-      return createContentResponse(
-        {
-          url: capture.page.url,
-          timestamp: body.capturedAt,
-          snapshot: proxyFallback || servedDifferent ? body.url : capture.page.snapshot,
-          content: body.text,
-          ...(body.mime ? { mime: body.mime } : {}),
-          bytes: body.bytes,
-          truncated: body.truncated,
-          _meta: {
-            provider: "memento",
-            ...(typeof archive === "string" ? { archive } : {}),
-            ...(typeof datetime === "string" ? { datetime } : {}),
-            status: body.status,
-            aggregator: baseURL,
-            rawSnapshot: body.url,
-            ...(proxyFallback ? { proxyFallback: true } : {}),
-          },
-        },
-        "memento",
-        { requestedTimestamp: wanted || undefined, aggregator: baseURL },
-      );
+      const playback = await this.readCapture(capture, options);
+      return mementoContentResponse(capture, playback, wanted);
     } catch (error) {
       return createContentErrorResponse(error, "memento");
     }
   }
 
+  private async readCapture(
+    capture: Readonly<MementoCapture>,
+    options: Readonly<MementoOptions & ArchiveContentOptions>,
+  ): Promise<MementoPlayback> {
+    const baseURL = this.baseURL(options);
+    const aggregator = new URL(baseURL);
+    const localOrigin = isLocalDevelopmentHostname(aggregator.hostname)
+      ? aggregator.origin
+      : undefined;
+
+    try {
+      const snapshot = this.rawSnapshotURL(capture.page.snapshot);
+      const body = await fetchBody(
+        snapshot.origin,
+        `${snapshot.pathname}${snapshot.search}`,
+        options,
+        { assertURL: (candidate) => assertSafePlaybackURL(candidate) },
+      );
+      if (!body.capturedAt) throw new Error("Direct playback did not identify its capture time");
+      return { body: { ...body, capturedAt: body.capturedAt }, baseURL, proxyFallback: false };
+    } catch {
+      const body = await fetchBody(
+        baseURL,
+        `/memento/proxy/${capture.timestamp}/${encodeURIComponent(capture.page.url)}`,
+        options,
+        { assertURL: (candidate) => assertSafePlaybackURL(candidate, localOrigin) },
+      );
+      if (!body.capturedAt) throw new Error("Memento playback did not identify its capture time");
+      return { body: { ...body, capturedAt: body.capturedAt }, baseURL, proxyFallback: true };
+    }
+  }
+
   private async fetchTimeMap(
     target: string,
-    options: MementoOptions & ArchiveContentOptions,
+    options: Readonly<MementoOptions & ArchiveContentOptions>,
   ): Promise<{ pages: ArchivedPage[] }> {
     const baseURL = this.baseURL(options);
     let response: unknown;
@@ -274,74 +435,35 @@ export class MementoProvider extends BaseProvider<MementoOptions> {
     const latestPossibleCapture = Date.now() + MAX_CAPTURE_CLOCK_SKEW_MS;
 
     for (const memento of timeMap.mementos) {
-      const stamp = toWaybackTimestamp(memento.datetime);
-      if (stamp.length !== 14) continue;
-      const timestamp = waybackTimestampToISO(stamp);
-      if (!timestamp || Date.parse(timestamp) > latestPossibleCapture) continue;
-
-      let snapshot: URL;
-      try {
-        snapshot = new URL(memento.uri);
-      } catch {
-        continue;
-      }
-      if (!isSafeMementoURL(snapshot)) continue;
-
-      const key = `${timestamp}\u0000${snapshot.href}`;
+      const page = pageFromMemento(memento, timeMap.originalUri, latestPossibleCapture);
+      if (!page) continue;
+      const key = `${page.timestamp}\u0000${page.snapshot}`;
       if (seen.has(key)) continue;
       seen.add(key);
-
-      pages.push({
-        url: timeMap.originalUri,
-        timestamp,
-        snapshot: snapshot.href,
-        _meta: {
-          provider: "memento",
-          archive: snapshot.hostname,
-          datetime: memento.datetime,
-        },
-      });
+      pages.push(page);
     }
 
     return { pages };
   }
 
   private parseTimeMap(response: unknown): ParsedTimeMap {
-    if (!isRecord(response) || typeof response["original_uri"] !== "string") {
+    if (!isRecord(response)) {
       throw new Error("Memento aggregator returned a JSON TimeMap without original_uri");
     }
     const mementos = response["mementos"];
-    if (!isRecord(mementos) || !Array.isArray(mementos["list"])) {
+    if (!isRecord(mementos)) {
       throw new Error("Memento aggregator returned a JSON TimeMap without a valid mementos.list");
     }
-
-    let original: URL;
-    try {
-      original = new URL(response["original_uri"]);
-    } catch {
-      throw new Error("Memento aggregator returned an invalid original_uri");
-    }
-    if (original.protocol !== "http:" && original.protocol !== "https:") {
-      throw new Error("Memento aggregator returned original_uri without HTTP or HTTPS");
-    }
-    if (original.username || original.password) {
-      throw new Error("Memento aggregator returned an original_uri containing credentials");
-    }
-
-    const list: JsonTimeMapMemento[] = [];
-    for (const item of mementos["list"]) {
-      if (!isRecord(item)) continue;
-      const datetime = item["datetime"];
-      const uri = item["uri"];
-      if (typeof datetime === "string" && typeof uri === "string") {
-        list.push({ datetime, uri });
-      }
-    }
-
-    return { originalUri: original.href, mementos: list };
+    const original = parseOriginalUri(response["original_uri"]);
+    return { originalUri: original.href, mementos: parseMementoList(mementos["list"]) };
   }
 
-  /** Requests raw replay used by PyWB without the archive toolbar or rewritten links. */
+  /**
+   * Requests raw replay used by PyWB without the archive toolbar or rewritten links.
+   *
+   * @param value - Value.
+   * @returns {URL} The operation result.
+   */
   private rawSnapshotURL(value: string): URL {
     const snapshot = new URL(value);
     const path = snapshot.pathname;
@@ -382,30 +504,11 @@ export class MementoProvider extends BaseProvider<MementoOptions> {
     return target;
   }
 
-  private baseURL(options: Partial<MementoOptions>): string {
-    const raw = options.baseUrl ?? DEFAULT_BASE_URL;
-    let parsed: URL;
-    try {
-      parsed = new URL(raw);
-    } catch {
-      throw new Error("Invalid Memento aggregator base URL");
-    }
-    const localDevelopment = isLocalDevelopmentHostname(parsed.hostname);
-    if (isUnsafeHostname(parsed.hostname) && !localDevelopment) {
-      throw new Error("Memento aggregator base URL must use a public host");
-    }
-    if (parsed.protocol !== "https:" && !(parsed.protocol === "http:" && localDevelopment)) {
-      throw new Error("Memento aggregator base URL must use HTTPS (HTTP is allowed only locally)");
-    }
-    if (parsed.username || parsed.password || parsed.search || parsed.hash) {
-      throw new Error(
-        "Memento aggregator base URL cannot contain credentials, a query, or a fragment",
-      );
-    }
-    return parsed.href.replace(/\/$/, "");
+  private baseURL(options: Readonly<Partial<MementoOptions>>): string {
+    return parseAggregatorBaseUrl(options.baseUrl ?? DEFAULT_BASE_URL);
   }
 }
 
-export default function memento(initOptions: MementoOptions = {}): MementoProvider {
+export default function memento(initOptions: Readonly<MementoOptions> = {}): MementoProvider {
   return new MementoProvider(initOptions);
 }

--- a/src/providers/permacc.ts
+++ b/src/providers/permacc.ts
@@ -48,41 +48,79 @@ function normalizeExactUrl(input: string): string {
 const ISO_TIMESTAMP_PATTERN =
   /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
 
+interface TimestampParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+}
+
+function timestampParts(match: readonly string[]): TimestampParts {
+  return {
+    year: Number(match[1]),
+    month: Number(match[2]),
+    day: Number(match[3]),
+    hour: Number(match[4]),
+    minute: Number(match[5]),
+    second: Number(match[6]),
+  };
+}
+
+function validClock(parts: Readonly<TimestampParts>): boolean {
+  return !(
+    parts.month < 1 ||
+    parts.month > 12 ||
+    parts.hour > 23 ||
+    parts.minute > 59 ||
+    parts.second > 59
+  );
+}
+
+function monthLength(year: number, month: number): number {
+  const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  if (month === 2) return leap ? 29 : 28;
+  return [4, 6, 9, 11].includes(month) ? 30 : 31;
+}
+
 function parseCreationTimestamp(value: string): string | undefined {
   const match = ISO_TIMESTAMP_PATTERN.exec(value);
   if (!match) return undefined;
-
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  const day = Number(match[3]);
-  const hour = Number(match[4]);
-  const minute = Number(match[5]);
-  const second = Number(match[6]);
-  if (month < 1 || month > 12 || hour > 23 || minute > 59 || second > 59) {
+  const parts = timestampParts(match);
+  if (!validClock(parts) || parts.day < 1 || parts.day > monthLength(parts.year, parts.month)) {
     return undefined;
   }
-
-  const isLeapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
-  const hasThirtyDays = month === 4 || month === 6 || month === 9 || month === 11;
-  const daysInMonth = month === 2 ? (isLeapYear ? 29 : 28) : hasThirtyDays ? 30 : 31;
-  if (day < 1 || day > daysInMonth) return undefined;
 
   const timestamp = new Date(value);
   return Number.isFinite(timestamp.getTime()) ? timestamp.toISOString() : undefined;
 }
 
-function mapArchive(value: unknown): ArchivedPage | undefined {
-  if (
-    typeof value !== "object" ||
-    value === null ||
-    !("guid" in value) ||
-    !("url" in value) ||
-    !("creation_timestamp" in value)
-  ) {
-    return undefined;
-  }
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
 
-  const { guid, url, creation_timestamp: creationTimestamp } = value;
+function archiveMetadata(
+  value: Readonly<Record<string, unknown>>,
+  guid: string,
+  timestamp: string,
+) {
+  const metadata: ArchivedPage["_meta"] = { guid, timestamp };
+  if (typeof value["title"] === "string") metadata.title = value["title"];
+  if (typeof value["status"] === "string") metadata.status = value["status"];
+
+  const createdBy = isRecord(value["created_by"]) ? value["created_by"]["id"] : undefined;
+  if (typeof createdBy === "string" || typeof createdBy === "number") {
+    metadata.created_by = String(createdBy);
+  }
+  return metadata;
+}
+
+function mapArchive(value: unknown): ArchivedPage | undefined {
+  if (!isRecord(value)) return undefined;
+  const guid = value["guid"];
+  const url = value["url"];
+  const creationTimestamp = value["creation_timestamp"];
   if (
     typeof guid !== "string" ||
     guid.length === 0 ||
@@ -102,27 +140,42 @@ function mapArchive(value: unknown): ArchivedPage | undefined {
     return undefined;
   }
 
-  const metadata: ArchivedPage["_meta"] = { guid, timestamp: creationTimestamp };
-  if ("title" in value && typeof value.title === "string") metadata.title = value.title;
-  if ("status" in value && typeof value.status === "string") metadata.status = value.status;
-
-  const createdBy =
-    "created_by" in value &&
-    typeof value.created_by === "object" &&
-    value.created_by !== null &&
-    "id" in value.created_by
-      ? value.created_by.id
-      : undefined;
-  if (typeof createdBy === "string" || typeof createdBy === "number") {
-    metadata.created_by = String(createdBy);
-  }
-
   return {
     url: archivedUrl,
     timestamp,
     snapshot: `https://perma.cc/${encodeURIComponent(guid)}`,
-    _meta: metadata,
+    _meta: archiveMetadata(value, guid, creationTimestamp),
   };
+}
+
+interface PermaccPayload {
+  objects: readonly unknown[];
+  meta?: Readonly<Record<string, unknown>>;
+}
+
+function parsePermaccPayload(value: unknown): PermaccPayload {
+  if (!isRecord(value) || !Array.isArray(value["objects"])) {
+    throw new Error("Invalid Perma.cc API response");
+  }
+  return {
+    objects: value["objects"],
+    ...(isRecord(value["meta"]) ? { meta: value["meta"] } : {}),
+  };
+}
+
+function permaccResponseMetadata(
+  meta?: Readonly<Record<string, unknown>>,
+): Record<string, unknown> {
+  if (!meta) return {};
+  const result: Record<string, unknown> = {};
+  for (const key of ["limit", "offset", "total_count"] as const) {
+    if (typeof meta[key] === "number") result[key] = meta[key];
+  }
+  for (const key of ["next", "previous"] as const) {
+    const value = meta[key];
+    if (typeof value === "string" || value === null) result[key] = value;
+  }
+  return result;
 }
 
 /**
@@ -137,8 +190,12 @@ export class PermaccProvider extends BaseProvider<PermaccOptions> {
 
   /**
    * Partition responses by account and effective limit without storing the raw API key.
+
+   *
+   * @param options - Options.
+   * @returns {string | undefined} The operation result.
    */
-  override cacheKey(options?: ArchiveOptions): string | undefined {
+  override cacheKey(options?: Readonly<ArchiveOptions>): string | undefined {
     const apiKey = options?.apiKey ?? this.options.apiKey;
     if (!apiKey) return undefined;
 
@@ -149,10 +206,15 @@ export class PermaccProvider extends BaseProvider<PermaccOptions> {
 
   /**
    * Fetch archives matching one exact URL from the authenticated Perma.cc account.
+
+   *
+   * @param domain - Domain.
+   * @param reqOptions - Req Options.
+   * @returns {Promise<ArchiveResponse>} A promise resolving to the operation result.
    */
   async snapshots(
     domain: string,
-    reqOptions: Partial<PermaccOptions> = {},
+    reqOptions: Readonly<Partial<PermaccOptions>> = {},
   ): Promise<ArchiveResponse> {
     try {
       const options = await this.resolveOptions(reqOptions);
@@ -181,50 +243,14 @@ export class PermaccProvider extends BaseProvider<PermaccOptions> {
         },
       );
 
-      const response: unknown = await $fetch("/v1/archives/", fetchOptions);
-      if (
-        typeof response !== "object" ||
-        response === null ||
-        !("objects" in response) ||
-        !Array.isArray(response.objects)
-      ) {
-        throw new Error("Invalid Perma.cc API response");
-      }
-
-      const pages: ArchivedPage[] = [];
-      for (const archive of response.objects) {
-        const page = mapArchive(archive);
-        if (page) pages.push(page);
-      }
-
-      const responseMeta: Record<string, unknown> = {};
-      if ("meta" in response && typeof response.meta === "object" && response.meta !== null) {
-        if ("limit" in response.meta && typeof response.meta.limit === "number") {
-          responseMeta.limit = response.meta.limit;
-        }
-        if ("offset" in response.meta && typeof response.meta.offset === "number") {
-          responseMeta.offset = response.meta.offset;
-        }
-        if ("total_count" in response.meta && typeof response.meta.total_count === "number") {
-          responseMeta.total_count = response.meta.total_count;
-        }
-        if (
-          "next" in response.meta &&
-          (typeof response.meta.next === "string" || response.meta.next === null)
-        ) {
-          responseMeta.next = response.meta.next;
-        }
-        if (
-          "previous" in response.meta &&
-          (typeof response.meta.previous === "string" || response.meta.previous === null)
-        ) {
-          responseMeta.previous = response.meta.previous;
-        }
-      }
+      const payload = parsePermaccPayload(await $fetch("/v1/archives/", fetchOptions));
+      const pages = payload.objects
+        .map((archive) => mapArchive(archive))
+        .filter((page): page is ArchivedPage => page !== undefined);
 
       return createSuccessResponse(pages, "permacc", {
         queryParams: fetchOptions.params,
-        meta: responseMeta,
+        meta: permaccResponseMetadata(payload.meta),
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -235,7 +261,7 @@ export class PermaccProvider extends BaseProvider<PermaccOptions> {
 
   override content(
     _url: string,
-    _options: ArchiveContentOptions = {},
+    _options: Readonly<ArchiveContentOptions> = {},
   ): Promise<ArchiveContentResponse> {
     return Promise.resolve(
       createUnsupportedContentResponse(UNSUPPORTED_CONTENT_REASON, "permacc", {
@@ -245,6 +271,8 @@ export class PermaccProvider extends BaseProvider<PermaccOptions> {
   }
 }
 
-export default function permacc(initOptions: Partial<PermaccOptions> = {}): PermaccProvider {
+export default function permacc(
+  initOptions: Readonly<Partial<PermaccOptions>> = {},
+): PermaccProvider {
   return new PermaccProvider(initOptions);
 }

--- a/src/providers/wayback.ts
+++ b/src/providers/wayback.ts
@@ -32,6 +32,27 @@ interface CdxCapture {
 
 const BASE_URL = "https://web.archive.org";
 
+function requestedWindow(options: Readonly<WaybackOptions>): Record<string, string> {
+  const result: Record<string, string> = {};
+  const from = resolveRequestedTimestamp(options.from, "from");
+  const to = resolveRequestedTimestamp(options.to, "to");
+  if (from) result.from = from;
+  if (to) result.to = to;
+  return result;
+}
+
+function waybackQuery(domain: string, options: Readonly<WaybackOptions>): Record<string, string> {
+  const params: Record<string, string> = {
+    url: normalizeDomain(domain),
+    output: "json",
+    fl: "original,timestamp,statuscode",
+    collapse: options.collapse ?? "timestamp:4",
+    limit: String(options.limit ?? 1000),
+  };
+  if (options.filter !== undefined) params.filter = options.filter;
+  return { ...params, ...requestedWindow(options) };
+}
+
 /**
  * Wayback Machine archive provider.
  */
@@ -41,8 +62,12 @@ export class WaybackProvider extends BaseProvider<WaybackOptions> {
 
   /**
    * Cache key extension for options that change the CDX result set.
+
+   *
+   * @param options - Options.
+   * @returns {string} The resulting string.
    */
-  override cacheKey(options?: ArchiveOptions): string {
+  override cacheKey(options?: Readonly<ArchiveOptions>): string {
     const waybackOptions = options as Partial<WaybackOptions> | undefined;
     const collapse = waybackOptions?.collapse ?? this.options.collapse ?? "timestamp:4";
     const filter = waybackOptions?.filter ?? this.options.filter;
@@ -59,28 +84,20 @@ export class WaybackProvider extends BaseProvider<WaybackOptions> {
    * The window bounds are normalized here too, not only in `Archive.snapshots`:
    * the provider is a public export, and CDX does not read a raw ISO date as an
    * instant.
+
+   *
+   * @param domain - Domain.
+   * @param reqOptions - Req Options.
+   * @returns {Promise<ArchiveResponse>} A promise resolving to the operation result.
    */
-  async snapshots(domain: string, reqOptions: WaybackOptions = {}): Promise<ArchiveResponse> {
+  async snapshots(
+    domain: string,
+    reqOptions: Readonly<WaybackOptions> = {},
+  ): Promise<ArchiveResponse> {
     try {
       const options = await this.resolveOptions(reqOptions);
-      const baseUrl = BASE_URL;
-      const snapshotUrl = `${BASE_URL}/web`;
-      const urlPattern = normalizeDomain(domain);
-      const params: Record<string, string> = {
-        url: urlPattern,
-        output: "json",
-        fl: "original,timestamp,statuscode",
-        collapse: options.collapse ?? "timestamp:4",
-        limit: String(options.limit ?? 1000),
-      };
-
-      if (options.filter !== undefined) params.filter = options.filter;
-      const from = resolveRequestedTimestamp(options.from, "from");
-      const to = resolveRequestedTimestamp(options.to, "to");
-      if (from) params.from = from;
-      if (to) params.to = to;
-
-      const fetchOptions = await createFetchOptions(baseUrl, params, {
+      const params = waybackQuery(domain, options);
+      const fetchOptions = await createFetchOptions(BASE_URL, params, {
         retries: options.retries,
         signal: options.signal,
         timeout: options.timeout,
@@ -90,13 +107,18 @@ export class WaybackProvider extends BaseProvider<WaybackOptions> {
       const response = (await $fetch("/cdx/search/cdx", fetchOptions)) as WaybackResponse;
 
       if (!Array.isArray(response) || response.length <= 1) {
-        return createSuccessResponse([], "wayback", { queryParams: fetchOptions.params || {} });
+        return createSuccessResponse([], "wayback", { queryParams: fetchOptions.params ?? {} });
       }
 
       const dataRows = response.slice(1);
-      const pages: ArchivedPage[] = await mapCdxRows(dataRows, snapshotUrl, "wayback", options);
+      const pages: ArchivedPage[] = await mapCdxRows(
+        dataRows,
+        `${BASE_URL}/web`,
+        "wayback",
+        options,
+      );
 
-      return createSuccessResponse(pages, "wayback", { queryParams: fetchOptions.params || {} });
+      return createSuccessResponse(pages, "wayback", { queryParams: fetchOptions.params ?? {} });
     } catch (error) {
       return createErrorResponse(error, "wayback");
     }
@@ -108,10 +130,15 @@ export class WaybackProvider extends BaseProvider<WaybackOptions> {
    * Two steps, because the archive answers them at different endpoints: CDX says
    * which capture exists at the requested instant, and the playback endpoint
    * replays that capture's original bytes.
+
+   *
+   * @param url - Url.
+   * @param reqOptions - Req Options.
+   * @returns {Promise<ArchiveContentResponse>} A promise resolving to the operation result.
    */
   override async content(
     url: string,
-    reqOptions: Partial<WaybackOptions> & ArchiveContentOptions = {},
+    reqOptions: Readonly<Partial<WaybackOptions> & ArchiveContentOptions> = {},
   ): Promise<ArchiveContentResponse> {
     try {
       const options = await this.resolveContentOptions(reqOptions);
@@ -158,11 +185,17 @@ export class WaybackProvider extends BaseProvider<WaybackOptions> {
    * an unqualified request means; the second query runs only when the archive
    * holds nothing at or before the requested instant, and finds the closest
    * capture after it.
+
+   *
+   * @param target - Target.
+   * @param wanted - Wanted.
+   * @param options - Options.
+   * @returns {Promise<CdxCapture[]>} A promise resolving to the operation result.
    */
   private async findCaptures(
     target: string,
     wanted: string,
-    options: ArchiveContentOptions,
+    options: Readonly<ArchiveContentOptions>,
   ): Promise<CdxCapture[]> {
     const params: Record<string, string> = {
       url: target,
@@ -182,8 +215,8 @@ export class WaybackProvider extends BaseProvider<WaybackOptions> {
   }
 
   private async queryCaptures(
-    params: Record<string, string>,
-    options: ArchiveContentOptions,
+    params: Readonly<Record<string, string>>,
+    options: Readonly<ArchiveContentOptions>,
   ): Promise<CdxCapture[]> {
     const fetchOptions = await createFetchOptions(BASE_URL, params, {
       retries: options.retries,
@@ -212,6 +245,6 @@ export class WaybackProvider extends BaseProvider<WaybackOptions> {
   }
 }
 
-export default function wayback(initOptions: WaybackOptions = {}): WaybackProvider {
+export default function wayback(initOptions: Readonly<WaybackOptions> = {}): WaybackProvider {
   return new WaybackProvider(initOptions);
 }

--- a/src/providers/webcite.ts
+++ b/src/providers/webcite.ts
@@ -26,7 +26,10 @@ export class WebCiteProvider extends BaseProvider<WebCiteOptions> {
   readonly name = "WebCite";
   readonly slug = "webcite";
 
-  async snapshots(_domain: string, _options: WebCiteOptions = {}): Promise<ArchiveResponse> {
+  async snapshots(
+    _domain: string,
+    _options: Readonly<WebCiteOptions> = {},
+  ): Promise<ArchiveResponse> {
     return createUnsupportedResponse(UNSUPPORTED_LIST_REASON, "webcite", {
       operation: "snapshots",
     });
@@ -34,7 +37,7 @@ export class WebCiteProvider extends BaseProvider<WebCiteOptions> {
 
   override content(
     _url: string,
-    _options: ArchiveContentOptions = {},
+    _options: Readonly<ArchiveContentOptions> = {},
   ): Promise<ArchiveContentResponse> {
     return Promise.resolve(
       createUnsupportedContentResponse(UNSUPPORTED_CONTENT_REASON, "webcite", {
@@ -47,7 +50,13 @@ export class WebCiteProvider extends BaseProvider<WebCiteOptions> {
 /**
  * Create a WebCite archive provider.
  * Backwards-compatible functional factory; prefer `new WebCiteProvider(...)`.
+
+ *
+ * @param _initOptions - Init Options.
+ * @returns {ArchiveProvider} The operation result.
  */
-export default function webcite(_initOptions: Partial<WebCiteOptions> = {}): ArchiveProvider {
+export default function webcite(
+  _initOptions: Readonly<Partial<WebCiteOptions>> = {},
+): ArchiveProvider {
   return new WebCiteProvider(_initOptions);
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -16,6 +16,13 @@ export const storage: Storage = createStorage({
 let storagePrefix = "archives";
 let storageInitialized = false;
 
+type StorageConfigOptions = Readonly<{
+  driver?: Driver;
+  ttl?: number;
+  cache?: boolean;
+  prefix?: string;
+}>;
+
 interface StoredArchiveResponse {
   response: ArchiveResponse;
   expiresAt?: number;
@@ -57,7 +64,7 @@ function isExpired(expiresAt: number | undefined): boolean {
 interface CacheKeyProvider {
   name: string;
   slug?: string;
-  cacheKey?: (options?: ArchiveOptions) => string | undefined;
+  cacheKey?: (options?: Readonly<ArchiveOptions>) => string | undefined;
 }
 
 function getExpiresAt(ttl: ArchiveOptions["ttl"]): number | undefined {
@@ -68,7 +75,7 @@ function getExpiresAt(ttl: ArchiveOptions["ttl"]): number | undefined {
   return Date.now() + Math.max(0, ttl);
 }
 
-/**
+/*
  * Option-derived parts of one listing cache key.
  *
  * The window bounds belong here: a windowed fetch is served with the provider's
@@ -76,7 +83,10 @@ function getExpiresAt(ttl: ArchiveOptions["ttl"]): number | undefined {
  * capped one under the same provider and domain, and the bounds keep the two
  * entries apart.
  */
-function getCacheKeyParts(provider: CacheKeyProvider, options?: ArchiveOptions): string[] {
+function getCacheKeyParts(
+  provider: Readonly<CacheKeyProvider>,
+  options?: Readonly<ArchiveOptions>,
+): string[] {
   const parts: string[] = [];
 
   if (options?.limit !== undefined) parts.push(`limit=${options.limit}`);
@@ -114,11 +124,17 @@ export async function initStorage(): Promise<void> {
 
 /**
  * Generate a storage key for a domain request
+
+ *
+ * @param provider - Provider.
+ * @param domain - Domain.
+ * @param options - Options.
+ * @returns {string} The resulting string.
  */
 export function generateStorageKey(
-  provider: CacheKeyProvider,
+  provider: Readonly<CacheKeyProvider>,
   domain: string,
-  options?: ArchiveOptions,
+  options?: Readonly<ArchiveOptions>,
 ): string {
   const providerKey = provider.slug ?? provider.name;
   const keyParts = [providerKey, domain, ...getCacheKeyParts(provider, options)];
@@ -126,13 +142,33 @@ export function generateStorageKey(
   return `${storagePrefix}:${JSON.stringify(keyParts)}`;
 }
 
+async function restoreStoredResponse(
+  key: string,
+  cachedData: unknown,
+): Promise<ArchiveResponse | undefined> {
+  const parsedData: unknown = typeof cachedData === "string" ? JSON.parse(cachedData) : cachedData;
+  if (isArchiveResponse(parsedData)) return { ...parsedData, fromCache: true };
+  if (!isStoredArchiveResponse(parsedData)) return undefined;
+  if (isExpired(parsedData.expiresAt)) {
+    await storage.removeItem(key);
+    return undefined;
+  }
+  return { ...parsedData.response, fromCache: true };
+}
+
 /**
  * Get stored response if available
+
+ *
+ * @param provider - Provider.
+ * @param domain - Domain.
+ * @param options - Options.
+ * @returns {Promise<ArchiveResponse | undefined>} A promise resolving to the operation result.
  */
 export async function getStoredResponse(
-  provider: CacheKeyProvider,
+  provider: Readonly<CacheKeyProvider>,
   domain: string,
-  options?: ArchiveOptions,
+  options?: Readonly<ArchiveOptions>,
 ): Promise<ArchiveResponse | undefined> {
   if (options?.cache === false) {
     return undefined;
@@ -145,29 +181,9 @@ export async function getStoredResponse(
   const key = generateStorageKey(provider, domain, options);
 
   try {
-    const cachedData = await storage.getItem(key);
+    const cachedData: unknown = await storage.getItem(key);
     if (!cachedData) return undefined;
-
-    const parsedData = typeof cachedData === "string" ? JSON.parse(cachedData) : cachedData;
-
-    if (isArchiveResponse(parsedData)) {
-      return {
-        ...parsedData,
-        fromCache: true,
-      };
-    }
-
-    if (!isStoredArchiveResponse(parsedData)) return undefined;
-
-    if (isExpired(parsedData.expiresAt)) {
-      await storage.removeItem(key);
-      return undefined;
-    }
-
-    return {
-      ...parsedData.response,
-      fromCache: true,
-    };
+    return await restoreStoredResponse(key, cachedData);
   } catch (error) {
     consola.error(`Storage read/parse error for ${key}:`, error);
   }
@@ -177,12 +193,18 @@ export async function getStoredResponse(
 
 /**
  * Store response in storage
+
+ *
+ * @param provider - Provider.
+ * @param domain - Domain.
+ * @param response - Response.
+ * @param options - Options.
  */
 export async function storeResponse(
-  provider: CacheKeyProvider,
+  provider: Readonly<CacheKeyProvider>,
   domain: string,
   response: ArchiveResponse,
-  options?: ArchiveOptions,
+  options?: Readonly<ArchiveOptions>,
 ): Promise<void> {
   // Skip caching when caching is opted out or the response is not a success.
   // The success filter naturally excludes both runtime errors and unsupported
@@ -217,11 +239,17 @@ export async function storeResponse(
  * space, and both the requested capture and the byte cap are part of the key:
  * a caller asking for a different capture, or for more of the same one, is
  * asking a different question.
+
+ *
+ * @param provider - Provider.
+ * @param url - Url.
+ * @param options - Options.
+ * @returns {string} The resulting string.
  */
 export function generateContentStorageKey(
-  provider: CacheKeyProvider,
+  provider: Readonly<CacheKeyProvider>,
   url: string,
-  options?: ArchiveContentOptions,
+  options?: Readonly<ArchiveContentOptions>,
 ): string {
   const providerKey = provider.slug ?? provider.name;
   const keyParts = [providerKey, "content", url];
@@ -237,11 +265,17 @@ export function generateContentStorageKey(
 
 /**
  * Get a stored archived body if one is cached and still fresh
+
+ *
+ * @param provider - Provider.
+ * @param url - Url.
+ * @param options - Options.
+ * @returns {Promise<ArchiveContentResponse | undefined>} A promise resolving to the operation result.
  */
 export async function getStoredContent(
-  provider: CacheKeyProvider,
+  provider: Readonly<CacheKeyProvider>,
   url: string,
-  options?: ArchiveContentOptions,
+  options?: Readonly<ArchiveContentOptions>,
 ): Promise<ArchiveContentResponse | undefined> {
   if (options?.cache === false) {
     return undefined;
@@ -254,10 +288,11 @@ export async function getStoredContent(
   const key = generateContentStorageKey(provider, url, options);
 
   try {
-    const cachedData = await storage.getItem(key);
+    const cachedData: unknown = await storage.getItem(key);
     if (!cachedData) return undefined;
 
-    const parsedData = typeof cachedData === "string" ? JSON.parse(cachedData) : cachedData;
+    const parsedData: unknown =
+      typeof cachedData === "string" ? JSON.parse(cachedData) : cachedData;
     if (!isStoredArchiveContent(parsedData)) return undefined;
 
     if (isExpired(parsedData.expiresAt)) {
@@ -278,12 +313,18 @@ export async function getStoredContent(
 
 /**
  * Store an archived body in storage
+
+ *
+ * @param provider - Provider.
+ * @param url - Url.
+ * @param response - Response.
+ * @param options - Options.
  */
 export async function storeContent(
-  provider: CacheKeyProvider,
+  provider: Readonly<CacheKeyProvider>,
   url: string,
   response: ArchiveContentResponse,
-  options?: ArchiveContentOptions,
+  options?: Readonly<ArchiveContentOptions>,
 ): Promise<void> {
   if (options?.cache === false || !response.success || !response.content) {
     return;
@@ -310,9 +351,12 @@ export async function storeContent(
 
 /**
  * Clear stored responses for a specific provider
+
+ *
+ * @param provider - Provider.
  */
 export async function clearProviderStorage(
-  provider: string | { name: string; slug?: string },
+  provider: Readonly<string | { name: string; slug?: string }>,
 ): Promise<void> {
   try {
     if (!storageInitialized) {
@@ -337,15 +381,11 @@ export async function clearProviderStorage(
 /**
  * Configure storage options and driver
  * @deprecated Use config file or options passed to createArchive instead
+
+ *
+ * @param options - Options.
  */
-export async function configureStorage(
-  options: {
-    driver?: Driver;
-    ttl?: number;
-    cache?: boolean;
-    prefix?: string;
-  } = {},
-): Promise<void> {
+export async function configureStorage(options: StorageConfigOptions = {}): Promise<void> {
   const config = await getConfig();
 
   if (options.driver) {

--- a/src/tool-operations.ts
+++ b/src/tool-operations.ts
@@ -17,6 +17,7 @@ import type {
   ArchiveContentResponse,
   ArchiveOptions,
   ArchiveResponse,
+  ArchivedContent,
   ArchivedPage,
 } from "./types";
 import { htmlToText, isTextualMime, resolveRequestedTimestamp } from "./utils";
@@ -91,7 +92,7 @@ export const MAX_TIMEOUT = 5 * 60 * 1000;
 export const PERMACC_API_KEY_ENVS = ["PERMA_CC_API_KEY", "PERMACC_API_KEY"] as const;
 
 // oxlint-disable-next-line no-control-regex -- Terminal control bytes are precisely what this boundary removes.
-const UNSAFE_TERMINAL_CONTROLS = /[\u0000-\u0008\u000b-\u001f\u007f-\u009f]/gu;
+const UNSAFE_TERMINAL_CONTROLS = /[\u0000-\u0008\u000B-\u001F\u007F-\u009F]/gu;
 
 /** Options passed to a provider factory, including the provider-specific extras. */
 export type SnapshotOptions = ArchiveOptions & {
@@ -201,12 +202,15 @@ interface PermaccApiKeyState {
  * Queries one provider (or every provider in `all`) for archived snapshots.
  *
  * @param params - Tool arguments; `target` is a domain or URL
- * @returns Rendered snapshot list plus the raw response
- * @throws When the target is empty, the provider is unknown, or its prerequisites are missing
+ * @returns {Promise<ToolResult<SnapshotDetails>>} Rendered snapshot list plus the raw response
+ * @throws {Error} When the target is empty, the provider is unknown, or its prerequisites are missing
+
+ *
+ * @param signal - Signal.
  */
 export async function snapshotArchives(
-  params: SnapshotParams,
-  signal?: AbortSignal,
+  params: Readonly<SnapshotParams>,
+  signal?: Readonly<AbortSignal>,
 ): Promise<ToolResult<SnapshotDetails>> {
   const target = params.target.trim();
   if (!target) {
@@ -256,13 +260,16 @@ export async function snapshotArchives(
  * the capture.
  *
  * @param params - Tool arguments; `target` is a URL, archived or original
- * @returns The rendered body plus the capture it came from
- * @throws When the target is empty, an argument is out of range, the provider is
+ * @returns {Promise<ToolResult<ContentDetails>>} The rendered body plus the capture it came from
+ * @throws {Error} When the target is empty, an argument is out of range, the provider is
  * unknown, or its prerequisites are missing
+
+ *
+ * @param signal - Signal.
  */
 export async function contentArchives(
-  params: ContentParams,
-  signal?: AbortSignal,
+  params: Readonly<ContentParams>,
+  signal?: Readonly<AbortSignal>,
 ): Promise<ToolResult<ContentDetails>> {
   const target = params.target.trim();
   if (!target) {
@@ -275,7 +282,7 @@ export async function contentArchives(
   const provider = normalizeProvider(params.provider);
   const format = normalizeFormat(params.format);
   const maxChars = params.maxChars ?? DEFAULT_MAX_CHARS;
-  const options = { ...(await buildContentOptions(params, provider, format, maxChars)), signal };
+  const options = { ...(await buildContentOptions(params, format, maxChars)), signal };
   const archiveProvider = await createProvider(provider, options);
   const archive = createArchive(archiveProvider, options);
   const response = await archive.content(target, options);
@@ -319,7 +326,11 @@ export async function contentArchives(
   };
 }
 
-/** Lists the built-in providers, their `provider=all` membership, and Perma.cc key state. */
+/**
+ * Lists the built-in providers, their `provider=all` membership, and Perma.cc key state.
+ *
+ * @returns {ToolResult<ProvidersDetails>} The operation result.
+ */
 export function listArchiveProviders(): ToolResult<ProvidersDetails> {
   const statuses = getProviderStatuses();
   return {
@@ -330,7 +341,13 @@ export function listArchiveProviders(): ToolResult<ProvidersDetails> {
   };
 }
 
-/** Wayback-only lookup backing the interactive `/archive` command. */
+/**
+ * Wayback-only lookup backing the interactive `/archive` command.
+ *
+ * @param target - Target.
+ * @param limit - Limit.
+ * @returns {Promise<ArchiveResponse>} A promise resolving to the operation result.
+ */
 export async function waybackSnapshots(
   target: string,
   limit: number = DEFAULT_LIMIT,
@@ -340,44 +357,56 @@ export async function waybackSnapshots(
   return archive.snapshots(target, options);
 }
 
+type SingleProviderName = Exclude<ProviderName, "all">;
+type ProviderFactory = (
+  options: Readonly<SnapshotOptions | ContentOptions>,
+) => Promise<ArchiveProviderOrList>;
+
+function archiveItFactory(options: Readonly<SnapshotOptions | ContentOptions>) {
+  const collection = options.collection?.trim();
+  if (collection === undefined || !/^\d+$/.test(collection)) {
+    throw new Error("provider=archiveIt requires a numeric collection id.");
+  }
+  return providers.archiveIt({ ...options, collection });
+}
+
+function coniferFactory(options: Readonly<SnapshotOptions | ContentOptions>) {
+  const user = options.user?.trim();
+  const collection = options.collection?.trim();
+  if (!user || !collection) {
+    throw new Error("provider=conifer requires user and collection slugs.");
+  }
+  return providers.conifer({ ...options, user, collection });
+}
+
+const PROVIDER_FACTORIES: Readonly<Record<SingleProviderName, ProviderFactory>> = {
+  wayback: (options) => providers.wayback(options),
+  archiveIt: archiveItFactory,
+  conifer: coniferFactory,
+  archiveToday: (options) => providers.archiveToday(options),
+  memento: (options) => providers.memento(options),
+  commoncrawl: (options) => providers.commoncrawl(options),
+  webcite: (options) => providers.webcite(options),
+  permacc: (options) => providers.permacc(options),
+};
+
 async function createProvider(
   provider: ProviderName,
-  options: SnapshotOptions | ContentOptions,
+  options: Readonly<SnapshotOptions | ContentOptions>,
 ): Promise<ArchiveProviderOrList> {
-  if (provider === "all") return providers.all(options);
-  if (provider === "wayback") return providers.wayback(options);
-  if (provider === "archiveIt") {
-    const collection = options.collection?.trim();
-    if (collection === undefined || !/^\d+$/.test(collection)) {
-      throw new Error("provider=archiveIt requires a numeric collection id.");
-    }
-    return providers.archiveIt({ ...options, collection });
-  }
-  if (provider === "conifer") {
-    const user = options.user?.trim();
-    const collection = options.collection?.trim();
-    if (!user || !collection) {
-      throw new Error("provider=conifer requires user and collection slugs.");
-    }
-    return providers.conifer({ ...options, user, collection });
-  }
-  if (provider === "archiveToday") return providers.archiveToday(options);
-  if (provider === "memento") return providers.memento(options);
-  if (provider === "commoncrawl") return providers.commoncrawl(options);
-  if (provider === "webcite") return providers.webcite(options);
-  if (provider === "permacc") {
-    return providers.permacc(options as SnapshotOptions & { apiKey: string });
-  }
-  // A new entry in PROVIDERS reaches here instead of silently querying Perma.cc.
-  const unhandled: never = provider;
-  throw new Error(`Provider "${String(unhandled)}" has no factory.`);
+  return provider === "all" ? providers.all(options) : PROVIDER_FACTORIES[provider](options);
 }
 
 type ArchiveProviderOrList = Awaited<
   ReturnType<typeof providers.wayback> | ReturnType<typeof providers.all>
 >;
 
-/** Resolves a user-supplied provider name, accepting the kebab-case spellings. */
+/**
+ * Resolves a user-supplied provider name, accepting the kebab-case spellings.
+ *
+ * @param provider - Provider.
+ * @returns {ProviderName} The operation result.
+ */
 export function normalizeProvider(provider: string | undefined): ProviderName {
   const raw = (provider ?? "auto").trim() || "auto";
   const alias = PROVIDER_ALIASES[raw as keyof typeof PROVIDER_ALIASES];
@@ -413,7 +442,7 @@ const TEXT_BOUNDS = {
   to: MAX_TIMESTAMP_LENGTH,
 } as const satisfies Record<string, number>;
 
-/** Validates every bounded argument an operation's parameters happen to carry. */
+/* Validates every bounded argument an operation's parameters happen to carry. */
 function checkBounds(
   params: Partial<Record<keyof typeof NUMERIC_BOUNDS, number>> &
     Partial<Record<keyof typeof TEXT_BOUNDS, string>>,
@@ -426,7 +455,7 @@ function checkBounds(
   }
 }
 
-/**
+/*
  * Rejects an out-of-range argument the same way on every surface.
  *
  * A schema is the first line, not the only one: a fractional `limit` that slips
@@ -437,7 +466,7 @@ function checkNumber(name: keyof typeof NUMERIC_BOUNDS, value: number | undefine
   if (value === undefined) return;
   const { minimum, maximum } = NUMERIC_BOUNDS[name];
   if (!Number.isInteger(value)) {
-    throw new Error(`${name} must be a whole number`);
+    throw new TypeError(`${name} must be a whole number`);
   }
   if (value < minimum || value > maximum) {
     throw new Error(`${name} must be between ${minimum} and ${maximum}`);
@@ -451,38 +480,59 @@ function checkText(name: keyof typeof TEXT_BOUNDS, value: string | undefined): v
   }
 }
 
-function buildSnapshotOptions(params: SnapshotParams, provider: ProviderName): SnapshotOptions {
-  checkBounds(params);
+const SNAPSHOT_OPTION_KEYS = [
+  "cache",
+  "ttl",
+  "concurrency",
+  "batchSize",
+  "timeout",
+  "retries",
+  "collection",
+  "user",
+  "collapse",
+  "filter",
+  "from",
+  "to",
+] as const satisfies readonly (keyof SnapshotParams & keyof SnapshotOptions)[];
 
-  const limit = params.limit ?? DEFAULT_LIMIT;
-  const options: SnapshotOptions = { limit };
-  if (params.cache !== undefined) options.cache = params.cache;
-  if (params.ttl !== undefined) options.ttl = params.ttl;
-  if (params.concurrency !== undefined) options.concurrency = params.concurrency;
-  if (params.batchSize !== undefined) options.batchSize = params.batchSize;
-  if (params.timeout !== undefined) options.timeout = params.timeout;
-  if (params.retries !== undefined) options.retries = params.retries;
-  if (params.collection !== undefined) options.collection = params.collection;
-  if (params.user !== undefined) options.user = params.user;
-  if (params.collapse !== undefined) options.collapse = params.collapse;
-  if (params.filter !== undefined) options.filter = params.filter;
-  if (params.from !== undefined) options.from = params.from;
-  if (params.to !== undefined) options.to = params.to;
-
-  if (provider === "permacc") {
-    const { apiKey } = getPermaccApiKeyState();
-    if (!apiKey) {
-      throw new Error(
-        `Perma.cc provider requires an API key in ${PERMACC_API_KEY_ENVS.join(" or ")}.`,
-      );
-    }
-    options.apiKey = apiKey;
+function snapshotPassthroughOptions(params: Readonly<SnapshotParams>): Partial<SnapshotOptions> {
+  const result: Partial<SnapshotOptions> = {};
+  for (const key of SNAPSHOT_OPTION_KEYS) {
+    const value = params[key];
+    if (value !== undefined) Object.assign(result, { [key]: value });
   }
+  return result;
+}
 
+function addPermaccApiKey(options: SnapshotOptions): void {
+  const { apiKey } = getPermaccApiKeyState();
+  if (!apiKey) {
+    throw new Error(
+      `Perma.cc provider requires an API key in ${PERMACC_API_KEY_ENVS.join(" or ")}.`,
+    );
+  }
+  options.apiKey = apiKey;
+}
+
+function buildSnapshotOptions(
+  params: Readonly<SnapshotParams>,
+  provider: ProviderName,
+): SnapshotOptions {
+  checkBounds(params);
+  const options: SnapshotOptions = {
+    limit: params.limit ?? DEFAULT_LIMIT,
+    ...snapshotPassthroughOptions(params),
+  };
+  if (provider === "permacc") addPermaccApiKey(options);
   return options;
 }
 
-/** Resolves the requested rendering, rejecting a spelling no surface offers. */
+/**
+ * Resolves the requested rendering, rejecting a spelling no surface offers.
+ *
+ * @param format - Format.
+ * @returns {ContentFormat} The operation result.
+ */
 export function normalizeFormat(format: string | undefined): ContentFormat {
   const raw = (format ?? "text").trim() || "text";
   if (!(CONTENT_FORMATS as readonly string[]).includes(raw)) {
@@ -491,48 +541,64 @@ export function normalizeFormat(format: string | undefined): ContentFormat {
   return raw as ContentFormat;
 }
 
+const CONTENT_OPTION_KEYS = [
+  "cache",
+  "ttl",
+  "user",
+  "retries",
+  "collection",
+] as const satisfies readonly (keyof ContentParams & keyof ContentOptions)[];
+
+function contentPassthroughOptions(params: Readonly<ContentParams>): Partial<ContentOptions> {
+  const result: Partial<ContentOptions> = {};
+  for (const key of CONTENT_OPTION_KEYS) {
+    const value = params[key];
+    if (value !== undefined) Object.assign(result, { [key]: value });
+  }
+  return result;
+}
+
+function contentTimestamp(value: string | undefined): Partial<ContentOptions> {
+  if (value === undefined) return {};
+  const timestamp = resolveRequestedTimestamp(value);
+  return timestamp ? { timestamp } : {};
+}
+
+function contentByteLimit(format: ContentFormat, maxChars: number): number {
+  const requested = format === "raw" ? maxChars : maxChars * 8;
+  return Math.min(MAX_CONTENT_FETCH_BYTES, Math.max(MIN_CONTENT_FETCH_BYTES, requested));
+}
+
+/**
+ * Builds read options with extra byte headroom for markup and a slower archive timeout.
+ *
+ * @param params - Requested content parameters.
+ * @param format - Rendering format used to size the raw read.
+ * @param maxChars - Maximum rendered character count.
+ * @returns {Promise<ContentOptions>} Resolved options for one content request.
+ */
 async function buildContentOptions(
-  params: ContentParams,
-  provider: ProviderName,
+  params: Readonly<ContentParams>,
   format: ContentFormat,
   maxChars: number,
 ): Promise<ContentOptions> {
   checkBounds(params);
 
-  const options: ContentOptions = {
-    // Markup is most of an HTML capture's bytes and none of its text, so a text
-    // read has to fetch several times what it will hand back; a raw read hands
-    // back what it fetched. Both stay inside one fixed ceiling.
-    maxBytes: Math.min(
-      MAX_CONTENT_FETCH_BYTES,
-      Math.max(MIN_CONTENT_FETCH_BYTES, format === "raw" ? maxChars : maxChars * 8),
-    ),
-  };
-
-  if (params.timestamp !== undefined) {
-    // Rejected here rather than at the provider: an unusable instant would
-    // otherwise become a silent "newest capture" for some providers.
-    const timestamp = resolveRequestedTimestamp(params.timestamp);
-    if (timestamp) options.timestamp = timestamp;
-  }
-  if (params.cache !== undefined) options.cache = params.cache;
-  if (params.ttl !== undefined) options.ttl = params.ttl;
-  if (params.user !== undefined) options.user = params.user;
-  // Reading a page moves far more than a list of index rows, and archives replay
-  // captures slowly. A configured timeout above this floor is honored, so a host
-  // that already allows for slow archives keeps what it asked for.
   const { performance } = await getConfig();
-  options.timeout = params.timeout ?? Math.max(performance.timeout ?? 0, DEFAULT_CONTENT_TIMEOUT);
-  if (params.retries !== undefined) options.retries = params.retries;
-  if (params.collection !== undefined) options.collection = params.collection;
-
-  // No key is read here on purpose. Perma.cc serves no capture bodies, so its
-  // own unsupported answer is the useful one; demanding a key first would send
-  // the caller to fix an environment that changes nothing.
-  return options;
+  return {
+    maxBytes: contentByteLimit(format, maxChars),
+    ...contentTimestamp(params.timestamp),
+    ...contentPassthroughOptions(params),
+    timeout: params.timeout ?? Math.max(performance.timeout ?? 0, DEFAULT_CONTENT_TIMEOUT),
+  };
 }
 
-/** Strips private runtime state before options reach a transcript or a tool result. */
+/**
+ * Strips private runtime state before options reach a transcript or a tool result.
+ *
+ * @param options - Options.
+ * @returns {Omit<TOptions, "apiKey" | "signal"> & { apiKey?: "<redacted>" }} The operation result.
+ */
 export function redactOptions<TOptions extends { apiKey?: string; signal?: AbortSignal }>(
   options: TOptions,
 ): Omit<TOptions, "apiKey" | "signal"> & { apiKey?: "<redacted>" } {
@@ -631,7 +697,24 @@ function getProviderStatuses(): ProviderStatus[] {
   ];
 }
 
-/**
+function snapshotUnsupportedNote(response: ArchiveResponse): string {
+  const unsupported = response._meta?.unsupportedProviders;
+  return Array.isArray(unsupported) && unsupported.length > 0
+    ? `; unsupported=${unsupported.length}`
+    : "";
+}
+
+function snapshotWindowNote(options: Readonly<SnapshotOptions>): string {
+  if (options.from === undefined && options.to === undefined) return "";
+  return `; window=${sanitizeField(options.from ?? "")}..${sanitizeField(options.to ?? "")}`;
+}
+
+function snapshotFailureNote(response: ArchiveResponse): string {
+  const count = providerErrors(response).length;
+  return count > 0 ? `; failed=${count}` : "";
+}
+
+/*
  * One-line summary above the snapshot records.
  *
  * The applied window is part of it: a windowed listing that reads like the
@@ -641,20 +724,12 @@ function buildSnapshotHeader(
   provider: ProviderName,
   target: string,
   response: ArchiveResponse,
-  options: SnapshotOptions,
+  options: Readonly<SnapshotOptions>,
 ): string {
-  const unsupported = response._meta?.unsupportedProviders;
-  const unsupportedNote =
-    Array.isArray(unsupported) && unsupported.length > 0
-      ? `; unsupported=${unsupported.length}`
-      : "";
-  const failed = providerErrors(response);
-  const failedNote = failed.length > 0 ? `; failed=${failed.length}` : "";
+  const unsupportedNote = snapshotUnsupportedNote(response);
+  const failedNote = snapshotFailureNote(response);
   const errorNote = response.error ? `; error=${truncateSingleLine(response.error, 80)}` : "";
-  const windowNote =
-    options.from !== undefined || options.to !== undefined
-      ? `; window=${sanitizeField(options.from ?? "")}..${sanitizeField(options.to ?? "")}`
-      : "";
+  const windowNote = snapshotWindowNote(options);
   // The tool is annotated open-world, so a replay from the 7-day cache has to say
   // so rather than pass for a fresh read of the archive.
   const cacheNote = response.fromCache ? "; cached" : "";
@@ -672,7 +747,7 @@ function sanitizeResponse<TResponse extends { _meta?: ArchiveResponse["_meta"] }
   return { ...response, _meta: { ...safeMeta, errorDetails: "<redacted>" } };
 }
 
-/**
+/*
  * The capture as the transcript keeps it: metadata intact, body replaced by the
  * text the caller was handed.
  *
@@ -694,9 +769,9 @@ interface RenderedBody {
   clipped: boolean;
 }
 
-/** Formats one capture's body for a caller, and clips it to `maxChars`. */
+/* Formats one capture's body for a caller, and clips it to `maxChars`. */
 function renderBody(
-  capture: NonNullable<ArchiveContentResponse["content"]>,
+  capture: ArchivedContent,
   format: ContentFormat,
   maxChars: number,
 ): RenderedBody {
@@ -707,8 +782,8 @@ function renderBody(
   return { body, characters: body.length, clipped: body.length < formatted.length };
 }
 
-/** True when the capture is markup a reader would want stripped. */
-function isMarkup(capture: NonNullable<ArchiveContentResponse["content"]>): boolean {
+/* True when the capture is markup a reader would want stripped. */
+function isMarkup(capture: ArchivedContent): boolean {
   const mime = capture.mime;
   if (mime) return mime.includes("html") || mime.includes("xml");
   // Captures from before content types were reliable arrive without one.
@@ -719,7 +794,7 @@ function clipText(text: string, maxChars: number): string {
   if (text.length <= maxChars) return text;
 
   const clipped = text.slice(0, maxChars);
-  const lastCode = clipped.charCodeAt(clipped.length - 1);
+  const lastCode = clipped.codePointAt(clipped.length - 1) ?? 0;
   // Cutting between the halves of a surrogate pair leaves a lone code unit that
   // renders as a replacement character.
   return lastCode >= 0xd8_00 && lastCode <= 0xdb_ff ? clipped.slice(0, -1) : clipped;
@@ -729,7 +804,7 @@ function buildContentHeader(
   provider: ProviderName,
   target: string,
   response: ArchiveContentResponse,
-  rendered: RenderedBody,
+  rendered: Readonly<RenderedBody>,
 ): string {
   const capture = response.content;
   const cacheNote = response.fromCache ? "; cached" : "";
@@ -750,14 +825,17 @@ function buildContentHeader(
   ].join("\n");
 }
 
-/**
+/*
  * The lines below a content header: the body itself, or why there is none.
  *
  * The body is third-party text arriving in a context window, so it is fenced and
  * labelled: whatever an archived page says about what to do next, it is a
  * recording of a web page, not a message to the caller.
  */
-function contentBody(capture: ArchiveContentResponse["content"], rendered: RenderedBody): string[] {
+function contentBody(
+  capture: ArchivedContent | undefined,
+  rendered: Readonly<RenderedBody>,
+): string[] {
   if (!capture) return [];
 
   if (!isTextualMime(capture.mime)) {
@@ -786,86 +864,91 @@ function contentBody(capture: ArchiveContentResponse["content"], rendered: Rende
   ];
 }
 
-/** Reasons no capture could be read, named per provider. */
-function contentFailures(response: ArchiveContentResponse): string[] {
-  const lines: string[] = [];
-
+function providerFailureLines(response: ArchiveResponse | ArchiveContentResponse): string[] {
   const failed = providerErrors(response);
-  if (failed.length > 0) {
-    lines.push("", "Failed providers:");
-    for (const failure of failed) lines.push(`  ${sanitizeField(failure)}`);
-  }
+  return failed.length === 0
+    ? []
+    : ["", "Failed providers:", ...failed.map((failure) => `  ${sanitizeField(failure)}`)];
+}
 
+function unsupportedProviderLines(response: ArchiveResponse | ArchiveContentResponse): string[] {
   const unsupported = response._meta?.unsupportedProviders;
-  if (Array.isArray(unsupported) && unsupported.length > 0) {
-    lines.push("", "Unsupported providers:");
-    for (const record of unsupported) {
-      lines.push(`  ${sanitizeField(record.provider)}: ${sanitizeField(record.reason)}`);
-    }
-  }
+  if (!Array.isArray(unsupported) || unsupported.length === 0) return [];
+  const records = unsupported
+    .filter((record) => isUnsupportedRecord(record))
+    .map((record) => `  ${sanitizeField(record.provider)}: ${sanitizeField(record.reason)}`);
+  return ["", "Unsupported providers:", ...records];
+}
 
-  if (response.unsupportedReason && !Array.isArray(unsupported)) {
+/* Reasons no capture could be read, named per provider. */
+function contentFailures(response: ArchiveContentResponse): string[] {
+  const unsupportedLines = unsupportedProviderLines(response);
+  const lines = [...providerFailureLines(response), ...unsupportedLines];
+  const hasUnsupportedList = unsupportedLines.length > 0;
+  if (response.unsupportedReason && !hasUnsupportedList) {
     lines.push("", `Unsupported: ${sanitizeField(response.unsupportedReason)}`);
   }
-  if (response.error) {
-    lines.push("", `Error: ${sanitizeField(response.error)}`);
-  }
-
+  if (response.error) lines.push("", `Error: ${sanitizeField(response.error)}`);
   return lines;
 }
 
-/** Removes terminal control bytes that provider-supplied text could smuggle into a TUI. */
+/**
+ * Removes terminal control bytes that provider-supplied text could smuggle into a TUI.
+ *
+ * @param text - Text.
+ * @returns {string} The resulting string.
+ */
 export function sanitizeTerminalText(text: string): string {
   return text.replace(UNSAFE_TERMINAL_CONTROLS, "");
 }
 
-/** Reduces an error of unknown shape to one safe line. */
+/**
+ * Reduces an error of unknown shape to one safe line.
+ *
+ * @param error - Error.
+ * @returns {string} The resulting string.
+ */
 export function errorMessage(error: unknown): string {
   return sanitizeTerminalText(error instanceof Error ? error.message : String(error));
 }
 
-/** Names why a response carries no usable pages. */
+/**
+ * Names why a response carries no usable pages.
+ *
+ * @param response - Response.
+ * @returns {string} The resulting string.
+ */
 export function responseFailureMessage(response: ArchiveResponse): string {
   return sanitizeTerminalText(
     response.error ?? response.unsupportedReason ?? "Failed to fetch archive snapshots",
   );
 }
 
-function withHeader(header: string, body: string[]): string {
+function withHeader(header: string, body: readonly string[]): string {
   const joined = body.join("\n");
   return sanitizeTerminalText(joined ? `${header}\n\n${joined}` : `${header}\nNo snapshots.`);
 }
 
 function formatSnapshots(response: ArchiveResponse): string[] {
-  const lines = response.pages.map((page, index) => formatPage(page, index));
-  const unsupported = response._meta?.unsupportedProviders;
-  if (Array.isArray(unsupported) && unsupported.length > 0) {
-    lines.push("", "Unsupported providers:");
-    for (const item of unsupported) {
-      if (isUnsupportedRecord(item)) {
-        lines.push(`  ${sanitizeField(item.provider)}: ${sanitizeField(item.reason)}`);
-      }
-    }
-  }
-  // combineResults clears `error` as soon as one provider answered and parks the
-  // rest in `_meta.errors`; without this block a partial outage reads as a
-  // complete answer.
-  const failed = providerErrors(response);
-  if (failed.length > 0) {
-    lines.push("", "Failed providers:");
-    for (const failure of failed) lines.push(`  ${sanitizeField(failure)}`);
-  }
+  const lines = [
+    ...response.pages.map((page, index) => formatPage(page, index)),
+    ...unsupportedProviderLines(response),
+    ...providerFailureLines(response),
+  ];
   if (response.unsupportedReason) {
     lines.push("", `Unsupported: ${sanitizeField(response.unsupportedReason)}`);
   }
-  if (response.error) {
-    lines.push("", `Error: ${sanitizeField(response.error)}`);
-  }
+  if (response.error) lines.push("", `Error: ${sanitizeField(response.error)}`);
   return lines;
 }
 
-/** Per-provider failures, which a partially successful fan-out hides in `_meta`. */
-function providerErrors(response: { _meta?: ArchiveResponse["_meta"] }): string[] {
+/**
+ * Reads provider failures hidden in metadata by a partially successful fan-out.
+ *
+ * @param response - Archive response carrying provider metadata.
+ * @returns {string[]} Individual provider failures.
+ */
+function providerErrors(response: ArchiveResponse | ArchiveContentResponse): string[] {
   const errors = response._meta?.errors;
   return Array.isArray(errors) ? errors.filter((entry) => typeof entry === "string") : [];
 }
@@ -876,6 +959,11 @@ function providerErrors(response: { _meta?: ArchiveResponse["_meta"] }): string[
  * Every interpolated field is provider-supplied and goes through
  * {@link sanitizeField}: a newline inside a URL would otherwise close the record
  * and forge a second entry that reads exactly like a real snapshot.
+
+ *
+ * @param page - Page.
+ * @param index - Index.
+ * @returns {string} The resulting string.
  */
 export function formatPage(page: ArchivedPage, index?: number): string {
   const head = index === undefined ? "" : `${index + 1}. `;
@@ -884,13 +972,23 @@ export function formatPage(page: ArchivedPage, index?: number): string {
   return `${head}${sanitizeField(page.timestamp)}${provider}\n   ${sanitizeField(page.snapshot)}\n   original: ${sanitizeField(page.url)}`;
 }
 
-/** Reduces one untrusted field to a single line with no terminal control bytes. */
+/**
+ * Reduces one untrusted field to a single line with no terminal control bytes.
+ *
+ * @param value - Value.
+ * @returns {string} The resulting string.
+ */
 export function sanitizeField(value: string): string {
-  return sanitizeTerminalText(value).replace(/[\n\r\t]/g, " ");
+  return sanitizeTerminalText(value).replaceAll(/[\n\r\t]/g, " ");
 }
 
-/** Renders one provider row of {@link listArchiveProviders}. */
-export function formatProviderStatus(status: ProviderStatus): string {
+/**
+ * Renders one provider row of {@link listArchiveProviders}.
+ *
+ * @param status - Status.
+ * @returns {string} The resulting string.
+ */
+export function formatProviderStatus(status: Readonly<ProviderStatus>): string {
   const symbol = status.requiresApiKey && !status.configured ? "⚠" : "✓";
   const inAll = status.includedInAll ? " in provider=all" : "";
   const api = status.requiresApiKey ? " requires API key" : "";
@@ -908,8 +1006,14 @@ function isUnsupportedRecord(value: unknown): value is { provider: string; reaso
   );
 }
 
-/** Collapses whitespace and clips text to `maxLength`, for one-line call previews. */
+/**
+ * Collapses whitespace and clips text to `maxLength`, for one-line call previews.
+ *
+ * @param text - Text.
+ * @param maxLength - Max Length.
+ * @returns {string} The resulting string.
+ */
 export function truncateSingleLine(text: string, maxLength: number): string {
-  const singleLine = text.replace(/\s+/g, " ").trim();
+  const singleLine = text.replaceAll(/\s+/g, " ").trim();
   return singleLine.length <= maxLength ? singleLine : `${singleLine.slice(0, maxLength - 1)}…`;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,9 +195,12 @@ export interface ArchiveProvider {
   content?: (url: string, options?: ArchiveContentOptions) => Promise<ArchiveContentResponse>;
 }
 
+/** A provider instance or the lazy provider promise accepted by an archive. */
+export type ProviderReference = ArchiveProvider | Promise<ArchiveProvider>;
+
 /**
- * Interface for Archive instances
- * Defines the public API that all archive implementations must provide
+ * Interface for Archive instances.
+ * Defines the public API that all archive implementations must provide.
  */
 export interface ArchiveInterface {
   // Configuration options
@@ -210,6 +213,6 @@ export interface ArchiveInterface {
   getContent(url: string, options?: ArchiveContentOptions): Promise<ArchivedContent>;
 
   // Provider management
-  use(provider: ArchiveProvider | Promise<ArchiveProvider>): Promise<ArchiveInterface>;
-  useAll(providers: (ArchiveProvider | Promise<ArchiveProvider>)[]): Promise<ArchiveInterface>;
+  use(provider: ProviderReference): Promise<ArchiveInterface>;
+  useAll(providers: readonly ProviderReference[]): Promise<ArchiveInterface>;
 }

--- a/src/utils/_content.ts
+++ b/src/utils/_content.ts
@@ -43,8 +43,13 @@ const CHARSET_PARAMETER = /charset\s*=\s*"?([\w-]+)"?/i;
 const META_CHARSET = /<meta[^>]+charset\s*=\s*["']?\s*([\w-]+)/i;
 const HTTP_STATUS_LINE = /^HTTP\/[\d.]+\s+(\d{3})/i;
 
-/** Effective byte cap for one content request. */
-export function resolveMaxBytes(options: ArchiveContentOptions = {}): number {
+/**
+ * Effective byte cap for one content request.
+ *
+ * @param options - Options.
+ * @returns {number} The resulting number.
+ */
+export function resolveMaxBytes(options: Readonly<ArchiveContentOptions> = {}): number {
   const requested = options.maxBytes;
   if (typeof requested !== "number" || !Number.isFinite(requested)) {
     return DEFAULT_MAX_CONTENT_BYTES;
@@ -59,7 +64,7 @@ export function resolveMaxBytes(options: ArchiveContentOptions = {}): number {
  * so padding it to `20190101000000` would silently ask for the opposite window.
  *
  * @param value - Wayback-style digits or an ISO 8601 date
- * @returns Validated timestamp digits, or an empty string when unusable
+ * @returns {string} Validated timestamp digits, or an empty string when unusable
  */
 export function toWaybackTimestamp(value: string): string {
   const raw = value.trim();
@@ -86,7 +91,7 @@ function isoToWaybackDigits(value: string): string {
     const parsable = /^[+-]\d{2}$/.test(offset) ? `${trimmed}:00` : trimmed;
     const instant = new Date(parsable);
     if (Number.isNaN(instant.getTime())) return "";
-    return instant.toISOString().replace(/\D/g, "").slice(0, 14);
+    return instant.toISOString().replaceAll(/\D/g, "").slice(0, 14);
   }
 
   const match = ISO_LIKE_TIMESTAMP.exec(trimmed);
@@ -102,8 +107,8 @@ function isoToWaybackDigits(value: string): string {
  *
  * @param timestamp - Requested capture time, or nothing for the newest capture
  * @param name - Which option the value came from, for the error message
- * @returns Validated timestamp digits, empty when none was requested
- * @throws When the value is not a timestamp any archive could act on
+ * @returns {string} Validated timestamp digits, empty when none was requested
+ * @throws {Error} When the value is not a timestamp any archive could act on
  */
 export function resolveRequestedTimestamp(
   timestamp: string | undefined,
@@ -124,6 +129,10 @@ export function resolveRequestedTimestamp(
 /**
  * Pads a possibly partial timestamp to the upper edge of the period it names,
  * so `2019` compares as the last instant of 2019 rather than its first.
+
+ *
+ * @param timestamp - Timestamp.
+ * @returns {string} The resulting string.
  */
 export function timestampUpperBound(timestamp: string): string {
   return timestamp.length >= 14 ? timestamp : timestamp + "9".repeat(14 - timestamp.length);
@@ -132,6 +141,10 @@ export function timestampUpperBound(timestamp: string): string {
 /**
  * Pads a possibly partial timestamp to the lower edge of the period it names.
  * The counterpart of {@link timestampUpperBound}, for the `from` side of a window.
+
+ *
+ * @param timestamp - Timestamp.
+ * @returns {string} The resulting string.
  */
 export function timestampLowerBound(timestamp: string): string {
   return timestamp.length >= 14 ? timestamp : timestamp + "0".repeat(14 - timestamp.length);
@@ -145,7 +158,7 @@ export function timestampLowerBound(timestamp: string): string {
  * itself*, and that query answers with something, which is worse than failing.
  *
  * @param input - Any URL, archived or not
- * @returns The original URL, plus the capture timestamp when the input carried one
+ * @returns {{ url: string; timestamp?: string }} The original URL, plus the capture timestamp when the input carried one
  */
 export function unwrapSnapshotUrl(input: string): { url: string; timestamp?: string } {
   const raw = input.trim();
@@ -167,6 +180,9 @@ export function unwrapSnapshotUrl(input: string): { url: string; timestamp?: str
  * no capture exists.
  *
  * @param url - Target as the caller supplied it
+
+ *
+ * @returns {string | undefined} The operation result.
  */
 export function unreadableTargetReason(url: string): string | undefined {
   if (/^https?:\/\/data\.commoncrawl\.org\//i.test(url.trim())) {
@@ -186,15 +202,18 @@ export function unreadableTargetReason(url: string): string | undefined {
  * @param captures - Candidates from the index
  * @param target - URL the caller asked for
  * @param urlOf - Reads the URL a candidate was recorded under
+
+ *
+ * @returns {T[]} The resulting values.
  */
 export function preferSameUrl<T>(
-  captures: T[],
+  captures: readonly T[],
   target: string,
   urlOf: (capture: T) => string,
 ): T[] {
   const wanted = canonicalUrlKey(target);
   const sameUrl = captures.filter((capture) => canonicalUrlKey(urlOf(capture)) === wanted);
-  if (sameUrl.length === 0) return captures;
+  if (sameUrl.length === 0) return [...captures];
 
   // A CDX key drops the scheme too, so the index answers a request for the HTTPS
   // page with the HTTP captures beside it. Narrow to the scheme the caller wrote,
@@ -211,7 +230,7 @@ function schemeOf(value: string): string {
   return /^(https?):\/\//i.exec(value.trim())?.[1].toLowerCase() ?? "";
 }
 
-/** Reduces a URL to the differences that matter when comparing two spellings of it. */
+/* Reduces a URL to the differences that matter when comparing two spellings of it. */
 function canonicalUrlKey(value: string): string {
   return (
     value
@@ -232,9 +251,12 @@ function canonicalUrlKey(value: string): string {
  *
  * @param captures - Candidates carrying Wayback-style timestamp digits
  * @param timestamp - Validated timestamp digits, possibly partial
+
+ *
+ * @returns {T | undefined} The operation result.
  */
 export function selectCapture<T extends { timestamp: string; status?: number }>(
-  captures: T[],
+  captures: readonly T[],
   timestamp?: string,
 ): T | undefined {
   if (captures.length === 0) return undefined;
@@ -260,7 +282,7 @@ export function selectCapture<T extends { timestamp: string; status?: number }>(
   return atOrBefore.length > 0 ? pickPreferred(atOrBefore) : pickPreferred(ordered);
 }
 
-/**
+/*
  * Takes the first candidate that recorded a successful response, and the most
  * preferred one when none did.
  *
@@ -269,14 +291,14 @@ export function selectCapture<T extends { timestamp: string; status?: number }>(
  *
  * @param preferred - Candidates, most preferred first
  */
-function pickPreferred<T extends { status?: number }>(preferred: T[]): T | undefined {
+function pickPreferred<T extends { status?: number }>(preferred: readonly T[]): T | undefined {
   return (
     preferred.find((capture) => capture.status === undefined || isOkStatus(capture.status)) ??
     preferred[0]
   );
 }
 
-/** Orders timestamp digits chronologically, with a partial stamp before what it prefixes. */
+/* Orders timestamp digits chronologically, with a partial stamp before what it prefixes. */
 function compareTimestamps(left: string, right: string): number {
   if (left === right) return 0;
   return left < right ? -1 : 1;
@@ -305,9 +327,23 @@ export interface FetchBodyPolicy {
   maxRedirects?: number;
 }
 
+type FetchBodyOptions = Readonly<ArchiveContentOptions> & {
+  readonly headers?: Readonly<Record<string, string>>;
+};
+
+type PlaybackCaptureRequest = Readonly<{
+  baseURL: string;
+  prefix: string;
+  original: string;
+  stamp: string;
+  provider: string;
+  options: Readonly<ArchiveContentOptions>;
+  meta?: Readonly<Record<string, unknown>>;
+}>;
+
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
-/** Converts one final raw response into the bounded body contract. */
+/* Converts one final raw response into the bounded body contract. */
 async function decodeFetchedResponse(
   response: FetchResponse<unknown>,
   maxBytes: number,
@@ -327,46 +363,53 @@ async function decodeFetchedResponse(
   };
 }
 
-/**
- * GETs one URL and decodes at most `maxBytes` of its body.
- *
- * The body is streamed rather than buffered so the cap is a real one: an
- * archived 60 MB video must not be pulled into memory to be thrown away.
- * A policy switches redirects to manual handling so every destination can be
- * checked before the network request rather than only after it has happened.
- *
- * @param baseURL - Origin of the archive endpoint
- * @param path - Path to request, already URL-shaped
- * @param options - Byte cap plus the shared timeout and retry options
- * @param policy - Optional validation applied before the initial request and every redirect
- */
-export async function fetchBody(
+async function fetchUncheckedBody(
   baseURL: string,
   path: string,
-  options: ArchiveContentOptions & { headers?: Record<string, string> } = {},
-  policy?: FetchBodyPolicy,
+  options: Readonly<FetchBodyOptions>,
+  maxBytes: number,
 ): Promise<FetchedBody> {
-  const maxBytes = resolveMaxBytes(options);
+  const fetchOptions = await createFetchOptions(
+    baseURL,
+    {},
+    {
+      responseType: "stream",
+      retries: options.retries,
+      signal: options.signal,
+      timeout: options.timeout,
+      ...(options.headers ? { headers: options.headers } : {}),
+    },
+  );
+  const response = await $fetch.raw(path, fetchOptions);
+  return decodeFetchedResponse(response, maxBytes, `${baseURL}${path}`);
+}
 
-  if (!policy) {
-    const fetchOptions = await createFetchOptions(
-      baseURL,
-      {},
-      {
-        responseType: "stream",
-        retries: options.retries,
-        signal: options.signal,
-        timeout: options.timeout,
-        ...(options.headers ? { headers: options.headers } : {}),
-      },
-    );
-    const response = await $fetch.raw(path, fetchOptions);
-    return decodeFetchedResponse(response, maxBytes, `${baseURL}${path}`);
+async function redirectDestination(
+  response: FetchResponse<unknown>,
+  current: URL,
+  redirectCount: number,
+  maxRedirects: number,
+): Promise<URL> {
+  if (isReadableStream(response._data)) {
+    await response._data.cancel().catch(() => undefined);
   }
+  if (redirectCount >= maxRedirects) {
+    throw new Error(`Archive playback exceeded ${maxRedirects} redirects`);
+  }
+  const location = headerValue(response.headers, "location");
+  if (!location) throw new Error("Archive playback redirected without a Location header");
+  return new URL(location, current);
+}
 
+async function fetchPolicyBody(
+  baseURL: string,
+  path: string,
+  options: Readonly<FetchBodyOptions>,
+  policy: Readonly<FetchBodyPolicy>,
+  maxBytes: number,
+): Promise<FetchedBody> {
   const maxRedirects = policy.maxRedirects ?? 5;
   let current = new URL(path, baseURL);
-
   for (let redirectCount = 0; ; redirectCount++) {
     policy.assertURL(current);
     const fetchOptions = await createFetchOptions(
@@ -381,23 +424,40 @@ export async function fetchBody(
         ...(options.headers ? { headers: options.headers } : {}),
       },
     );
-    const requestPath = `${current.pathname}${current.search}`;
-    const response = await $fetch.raw(requestPath, fetchOptions);
-
+    const response = await $fetch.raw(`${current.pathname}${current.search}`, fetchOptions);
     if (!REDIRECT_STATUSES.has(response.status)) {
       return decodeFetchedResponse(response, maxBytes, current.href);
     }
-    if (isReadableStream(response._data)) {
-      await response._data.cancel().catch(() => undefined);
-    }
-    if (redirectCount >= maxRedirects) {
-      throw new Error(`Archive playback exceeded ${maxRedirects} redirects`);
-    }
-
-    const location = headerValue(response.headers, "location");
-    if (!location) throw new Error("Archive playback redirected without a Location header");
-    current = new URL(location, current);
+    current = await redirectDestination(response, current, redirectCount, maxRedirects);
   }
+}
+
+/**
+ * GETs one URL and decodes at most `maxBytes` of its body.
+ *
+ * The body is streamed rather than buffered so the cap is a real one: an
+ * archived 60 MB video must not be pulled into memory to be thrown away.
+ * A policy switches redirects to manual handling so every destination can be
+ * checked before the network request rather than only after it has happened.
+ *
+ * @param baseURL - Origin of the archive endpoint
+ * @param path - Path to request, already URL-shaped
+ * @param options - Byte cap plus the shared timeout and retry options
+ * @param policy - Optional validation applied before the initial request and every redirect
+
+ *
+ * @returns {Promise<FetchedBody>} A promise resolving to the operation result.
+ */
+export async function fetchBody(
+  baseURL: string,
+  path: string,
+  options: FetchBodyOptions = {},
+  policy?: Readonly<FetchBodyPolicy>,
+): Promise<FetchedBody> {
+  const maxBytes = resolveMaxBytes(options);
+  return policy
+    ? fetchPolicyBody(baseURL, path, options, policy, maxBytes)
+    : fetchUncheckedBody(baseURL, path, options, maxBytes);
 }
 
 /**
@@ -408,20 +468,13 @@ export async function fetchBody(
  * caller reads the archive's rendition instead of what the site served.
  *
  * @param params - Playback location, the capture to replay, and the read options
+
+ *
+ * @returns {Promise<ArchivedContent>} A promise resolving to the operation result.
  */
-export async function readPlaybackCapture(params: {
-  /** Origin of the playback host. */
-  baseURL: string;
-  /** Path segment before the timestamp, such as `/web` or `/4399`. */
-  prefix: string;
-  /** Original URL as the archive recorded it. */
-  original: string;
-  /** Capture timestamp digits. */
-  stamp: string;
-  provider: string;
-  options: ArchiveContentOptions;
-  meta?: Record<string, unknown>;
-}): Promise<ArchivedContent> {
+export async function readPlaybackCapture(
+  params: PlaybackCaptureRequest,
+): Promise<ArchivedContent> {
   const { baseURL, prefix, original, stamp, provider, options } = params;
   const body = await fetchBody(baseURL, `${prefix}/${stamp}id_/${original}`, options);
 
@@ -461,7 +514,10 @@ export async function readPlaybackCapture(params: {
  * @param source - Compressed payload, as a stream or as bytes
  * @param maxBytes - Cap on the decompressed size
  * @param format - Compression the payload carries
- * @throws When the runtime has no `DecompressionStream`
+ * @throws {Error} When the runtime has no `DecompressionStream`
+
+ *
+ * @returns {Promise<{ bytes: Uint8Array; truncated: boolean }>} A promise resolving to the operation result.
  */
 export async function decompress(
   source: unknown,
@@ -469,7 +525,9 @@ export async function decompress(
   format: CompressionFormat = "gzip",
 ): Promise<{ bytes: Uint8Array; truncated: boolean }> {
   if (typeof DecompressionStream !== "function") {
-    throw new Error("Reading Common Crawl records requires DecompressionStream in this runtime");
+    throw new TypeError(
+      "Reading Common Crawl records requires DecompressionStream in this runtime",
+    );
   }
 
   return readCappedBytes(
@@ -485,7 +543,13 @@ export async function decompress(
  * stored compressed. Decoding it as text without this produces bytes that look
  * like a broken charset and read like nothing at all.
  *
- * @throws For an encoding this runtime cannot undo, rather than returning noise
+ * @throws {Error} For an encoding this runtime cannot undo, rather than returning noise
+
+ *
+ * @param body - Body.
+ * @param encoding - Encoding.
+ * @param maxBytes - Max Bytes.
+ * @returns {Promise<{ bytes: Uint8Array; truncated: boolean }>} A promise resolving to the operation result.
  */
 export async function decodeContentEncoding(
   body: Uint8Array,
@@ -512,6 +576,10 @@ export async function decodeContentEncoding(
  *
  * The framing travelled with the response, so the size lines sit inside the
  * stored bytes and would otherwise be read as part of the page.
+
+ *
+ * @param body - Body.
+ * @returns {Uint8Array} The operation result.
  */
 export function dechunkHttpBody(body: Uint8Array): Uint8Array {
   const chunks: Uint8Array[] = [];
@@ -541,7 +609,7 @@ function indexOfCrlf(bytes: Uint8Array, from: number): number | undefined {
   return undefined;
 }
 
-function concatBytes(chunks: Uint8Array[]): Uint8Array {
+function concatBytes(chunks: readonly Uint8Array[]): Uint8Array {
   const total = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
   const bytes = new Uint8Array(total);
   let offset = 0;
@@ -552,7 +620,7 @@ function concatBytes(chunks: Uint8Array[]): Uint8Array {
   return bytes;
 }
 
-/**
+/*
  * Presents a fetched payload as a stream, so the cap applies while the bytes
  * arrive rather than after they are all in memory.
  */
@@ -574,6 +642,9 @@ function toByteStream(source: unknown) {
  * another blank line, and then the bytes the server sent.
  *
  * @param record - One decompressed WARC record
+
+ *
+ * @returns {{ httpHeaders: string; body: Uint8Array } | undefined} The operation result.
  */
 export function splitWarcRecord(
   record: Uint8Array,
@@ -598,7 +669,12 @@ export interface HttpHead {
   transferEncoding?: string;
 }
 
-/** Reads the status line and the headers that decide how to read the body. */
+/**
+ * Reads the status line and the headers that decide how to read the body.
+ *
+ * @param headers - Headers.
+ * @returns {HttpHead} The operation result.
+ */
 export function parseHttpHeaders(headers: string): HttpHead {
   const lines = headers.split(/\r?\n/);
   const statusMatch = HTTP_STATUS_LINE.exec(lines[0] ?? "");
@@ -620,32 +696,81 @@ export function parseHttpHeaders(headers: string): HttpHead {
   };
 }
 
-/** Slack to add to a byte cap so a record's headers do not eat the caller's budget. */
+/**
+ * Slack to add to a byte cap so a record's headers do not eat the caller's budget.
+ *
+ * @param maxBytes - Max Bytes.
+ * @returns {number} The resulting number.
+ */
 export function withHeaderSlack(maxBytes: number): number {
   return maxBytes + WARC_HEADER_SLACK;
 }
 
-/** Reduces a content type to its media type, dropping `; charset=…`. */
+/**
+ * Reduces a content type to its media type, dropping `; charset=…`.
+ *
+ * @param contentType - Content Type.
+ * @returns {string | undefined} The operation result.
+ */
 export function baseMime(contentType: string | undefined): string | undefined {
   if (!contentType) return undefined;
   const mime = contentType.split(";")[0]?.trim().toLowerCase();
   return mime || undefined;
 }
 
-/** True for the media types whose bodies are text a caller can read. */
+const TEXTUAL_APPLICATION_MIMES = new Set([
+  "application/json",
+  "application/xml",
+  "application/xhtml+xml",
+  "application/javascript",
+  "application/x-javascript",
+  "application/ecmascript",
+]);
+
+/**
+ * True for the media types whose bodies are text a caller can read.
+ *
+ * @param mime - Mime.
+ * @returns {boolean} Whether the condition is met.
+ */
 export function isTextualMime(mime: string | undefined): boolean {
   if (!mime) return true; // Unknown type: the decoded body is the only evidence either way.
   return (
     mime.startsWith("text/") ||
     mime.endsWith("+xml") ||
     mime.endsWith("+json") ||
-    mime === "application/json" ||
-    mime === "application/xml" ||
-    mime === "application/xhtml+xml" ||
-    mime === "application/javascript" ||
-    mime === "application/x-javascript" ||
-    mime === "application/ecmascript"
+    TEXTUAL_APPLICATION_MIMES.has(mime)
   );
+}
+
+interface HtmlChunk {
+  text: string;
+  cursor: number;
+}
+
+function commentChunk(lower: string, open: number): HtmlChunk | undefined {
+  const end = lower.indexOf("-->", open + 4);
+  return end === -1 ? undefined : { text: " ", cursor: end + 3 };
+}
+
+function opensMarkupAt(lower: string, open: number): boolean {
+  const value = lower.codePointAt(open + 1) ?? Number.NaN;
+  return isNameByte(value) || value === 47 || value === 33 || value === 63;
+}
+
+function noiseTagChunk(lower: string, tag: Readonly<TagName>, open: number): HtmlChunk | undefined {
+  const closeStart = indexOfClosingTag(lower, tag.name, open + tag.name.length + 1);
+  if (closeStart === -1) return undefined;
+  const closeEnd = indexOfTagEnd(lower, closeStart);
+  return closeEnd === -1 ? undefined : { text: " ", cursor: closeEnd + 1 };
+}
+
+function markupChunk(lower: string, open: number): HtmlChunk | undefined {
+  if (!opensMarkupAt(lower, open)) return { text: "<", cursor: open + 1 };
+  const tag = readTagName(lower, open);
+  if (!tag.closing && NOISE_TAGS.has(tag.name)) return noiseTagChunk(lower, tag, open);
+  const tagEnd = indexOfTagEnd(lower, open);
+  return tagEnd === -1 ? undefined : { text: endsLine(tag) ? "\n" : " ", cursor: tagEnd + 1 };
 }
 
 /**
@@ -658,15 +783,19 @@ export function isTextualMime(mime: string | undefined): boolean {
  * unterminated-construct pattern that job needs (`<!--…-->`, `<script>…</script>`,
  * `<[^>]*>`) backtracks quadratically over an input that never terminates them,
  * and an archived page is an input an attacker picks. Measured before the
- * rewrite: 128 KiB of bare `<` took 9.8 seconds of one CPU.
+ * rewrite: 128 KiB of bare `<` took 9.8 seconds of one CPU. An unterminated
+ * construct is treated as markup cut off by truncation, not reader-visible text.
  *
  * @param html - Archived markup
+
+ *
+ * @returns {string} The resulting string.
  */
 export function htmlToText(html: string): string {
   // Searches run against an ASCII-lowered copy so tag names match whatever case
   // the document used; `[A-Z]` preserves length, so the indices still address the
   // original and slices come out unchanged.
-  const lower = html.replace(/[A-Z]/g, (letter) => letter.toLowerCase());
+  const lower = html.replaceAll(/[A-Z]/g, (letter) => letter.toLowerCase());
   const parts: string[] = [];
   let cursor = 0;
 
@@ -678,49 +807,19 @@ export function htmlToText(html: string): string {
     }
     parts.push(html.slice(cursor, open));
 
-    if (lower.startsWith("<!--", open)) {
-      const commentEnd = lower.indexOf("-->", open + 4);
-      // An unterminated construct means truncation cut the document mid-markup,
-      // and what follows is its source rather than anything a reader would see.
-      if (commentEnd === -1) break;
-      parts.push(" ");
-      cursor = commentEnd + 3;
-      continue;
-    }
-
-    // A `<` that opens nothing is text. `Price: 2 < 3 and 5 > 4` would otherwise
-    // lose everything up to the next `>` as if it were a tag.
-    const afterAngle = lower.charCodeAt(open + 1);
-    const opensMarkup =
-      isNameByte(afterAngle) || afterAngle === 47 || afterAngle === 33 || afterAngle === 63;
-    if (!opensMarkup) {
-      parts.push("<");
-      cursor = open + 1;
-      continue;
-    }
-
-    const tag = readTagName(lower, open);
-    if (!tag.closing && NOISE_TAGS.has(tag.name)) {
-      const closeStart = indexOfClosingTag(lower, tag.name, open + tag.name.length + 1);
-      if (closeStart === -1) break;
-      const closeEnd = indexOfTagEnd(lower, closeStart);
-      if (closeEnd === -1) break;
-      parts.push(" ");
-      cursor = closeEnd + 1;
-      continue;
-    }
-
-    const tagEnd = indexOfTagEnd(lower, open);
-    if (tagEnd === -1) break;
-    parts.push(endsLine(tag) ? "\n" : " ");
-    cursor = tagEnd + 1;
+    const chunk = lower.startsWith("<!--", open)
+      ? commentChunk(lower, open)
+      : markupChunk(lower, open);
+    if (!chunk) break;
+    parts.push(chunk.text);
+    cursor = chunk.cursor;
   }
 
   return decodeEntities(parts.join(""))
     .split("\n")
-    .map((line) => line.replace(/[^\S\n]+/g, " ").trim())
+    .map((line) => line.replaceAll(/[^\S\n]+/g, " ").trim())
     .join("\n")
-    .replace(/\n{3,}/g, "\n\n")
+    .replaceAll(/\n{3,}/g, "\n\n")
     .trim();
 }
 
@@ -752,19 +851,19 @@ interface TagName {
   closing: boolean;
 }
 
-/** Reads the element name at a `<` position, lowercased and without its slash. */
+/* Reads the element name at a `<` position, lowercased and without its slash. */
 function readTagName(lower: string, open: number): TagName {
   let index = open + 1;
   const closing = lower[index] === "/";
   if (closing) index++;
 
   const start = index;
-  while (index < lower.length && isNameByte(lower.charCodeAt(index))) index++;
+  while (index < lower.length && isNameByte(lower.codePointAt(index) ?? Number.NaN)) index++;
 
   return { name: lower.slice(start, index), closing };
 }
 
-/**
+/*
  * Finds where a tag ends, ignoring a `>` inside a quoted attribute value.
  *
  * `<div title="1 > 0">` is valid markup, and stopping at the first `>` leaks the
@@ -789,7 +888,7 @@ function indexOfTagEnd(source: string, open: number): number {
   return -1;
 }
 
-/**
+/*
  * Finds the closing tag for one element name.
  *
  * The name has to end where the match ends: `</scripture>` inside a script is
@@ -803,7 +902,7 @@ function indexOfClosingTag(lower: string, name: string, from: number): number {
     const found = lower.indexOf(`</${name}`, cursor);
     if (found === -1) return -1;
 
-    const after = lower.charCodeAt(found + name.length + 2);
+    const after = lower.codePointAt(found + name.length + 2) ?? Number.NaN;
     // End of input, `>`, `/` or whitespace all close the name.
     if (Number.isNaN(after) || after === 62 || after === 47 || after <= 32) return found;
     cursor = found + 1;
@@ -817,7 +916,7 @@ function isNameByte(code: number): boolean {
   return (code >= 97 && code <= 122) || (code >= 48 && code <= 57);
 }
 
-function endsLine(tag: TagName): boolean {
+function endsLine(tag: Readonly<TagName>): boolean {
   return tag.closing ? BLOCK_TAGS.has(tag.name) : BREAK_TAGS.has(tag.name);
 }
 
@@ -840,7 +939,7 @@ const NAMED_ENTITIES: Record<string, string> = {
 };
 
 function decodeEntities(text: string): string {
-  return text.replace(/&(#x?[\da-f]+|[a-z]+);/gi, (match, entity: string) => {
+  return text.replaceAll(/&(#x?[\da-f]+|[a-z]+);/gi, (match, entity: string) => {
     const lowered = entity.toLowerCase();
     if (lowered.startsWith("#")) {
       const codePoint = lowered.startsWith("#x")
@@ -863,12 +962,15 @@ function decodeEntities(text: string): string {
  *
  * @param bytes - Body of the archived response
  * @param contentType - Content type the archive recorded for it
+
+ *
+ * @returns {string} The resulting string.
  */
 export function decodeArchivedBody(bytes: Uint8Array, contentType?: string): string {
   return decodeBytes(bytes, charsetOf(contentType, bytes));
 }
 
-/** Picks the character set to decode with: the declared one, then the document's own. */
+/* Picks the character set to decode with: the declared one, then the document's own. */
 function charsetOf(contentType: string | undefined, bytes: Uint8Array): string | undefined {
   const declared = contentType ? CHARSET_PARAMETER.exec(contentType)?.[1] : undefined;
   if (declared) return declared;
@@ -900,7 +1002,7 @@ function parseMementoDatetime(value: string | undefined): string | undefined {
   return parsed.toISOString().replace(/\.\d{3}Z$/, "Z");
 }
 
-/** Reads a header from either a `Headers` instance or a plain record. */
+/* Reads a header from either a `Headers` instance or a plain record. */
 function headerValue(headers: unknown, name: string): string | undefined {
   if (!headers || typeof headers !== "object") return undefined;
 
@@ -916,7 +1018,7 @@ function headerValue(headers: unknown, name: string): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
-/**
+/*
  * Reads at most `maxBytes` from whatever ofetch produced for the body.
  *
  * A stream is the normal case; the buffer and string branches keep the helper
@@ -962,7 +1064,7 @@ function isReadableStream(value: unknown): value is ReadableStream<Uint8Array> {
 }
 
 async function readStream(
-  stream: ReadableStream<Uint8Array>,
+  stream: Readonly<ReadableStream<Uint8Array>>,
   maxBytes: number,
 ): Promise<{ bytes: Uint8Array; truncated: boolean }> {
   const reader = stream.getReader();
@@ -1001,7 +1103,7 @@ async function readStream(
   return { bytes: concatBytes(chunks), truncated };
 }
 
-/** Locates the blank line separating a header block from what follows it. */
+/* Locates the blank line separating a header block from what follows it. */
 function indexOfBlankLine(
   bytes: Uint8Array,
   from: number,

--- a/src/utils/_utils.ts
+++ b/src/utils/_utils.ts
@@ -16,9 +16,9 @@ const ALLOWED_WAYBACK_TIMESTAMP_LENGTHS = new Set([4, 6, 8, 10, 12, 14]);
 
 // Utility for parallel processing with concurrency control
 export async function processInParallel<T, R>(
-  items: T[],
+  items: readonly T[],
   processFunction: (item: T) => Promise<R>,
-  options: { concurrency?: number; batchSize?: number } = {},
+  options: Readonly<{ concurrency?: number; batchSize?: number }> = {},
 ): Promise<R[]> {
   const config = await getConfig();
   const concurrency = options.concurrency ?? config.performance.concurrency ?? 3;
@@ -42,7 +42,7 @@ export async function processInParallel<T, R>(
   return results;
 
   // Helper function to process a batch with concurrency limit
-  async function processBatch(batch: T[], limit: number): Promise<R[]> {
+  async function processBatch(batch: readonly T[], limit: number): Promise<R[]> {
     const FAILED = Symbol("failed");
     const batchResults: Array<R | typeof FAILED> = Array.from(
       { length: batch.length },
@@ -76,12 +76,58 @@ export async function processInParallel<T, R>(
   }
 }
 
+interface WaybackDateParts {
+  year: string;
+  month: string;
+  day: string;
+  hour: string;
+  minute: string;
+  second: string;
+}
+
+function waybackDateParts(value: string): WaybackDateParts {
+  return {
+    year: value.slice(0, 4),
+    month: value.length >= 6 ? value.slice(4, 6) : "01",
+    day: value.length >= 8 ? value.slice(6, 8) : "01",
+    hour: value.length >= 10 ? value.slice(8, 10) : "00",
+    minute: value.length >= 12 ? value.slice(10, 12) : "00",
+    second: value.length >= 14 ? value.slice(12, 14) : "00",
+  };
+}
+
+function validWaybackDateParts(parts: Readonly<Record<keyof WaybackDateParts, number>>): boolean {
+  return !(
+    parts.month < 1 ||
+    parts.month > 12 ||
+    parts.day < 1 ||
+    parts.day > 31 ||
+    parts.hour > 23 ||
+    parts.minute > 59 ||
+    parts.second > 59
+  );
+}
+
+function sameUtcDate(
+  parsed: Readonly<Date>,
+  parts: Readonly<Record<keyof WaybackDateParts, number>>,
+): boolean {
+  return (
+    parsed.getUTCFullYear() === parts.year &&
+    parsed.getUTCMonth() + 1 === parts.month &&
+    parsed.getUTCDate() === parts.day &&
+    parsed.getUTCHours() === parts.hour &&
+    parsed.getUTCMinutes() === parts.minute &&
+    parsed.getUTCSeconds() === parts.second
+  );
+}
+
 /**
  * Converts a Wayback Machine timestamp to ISO8601 format
  * Supports CDX precisions: YYYY, YYYYMM, YYYYMMDD, YYYYMMDDhh,
  * YYYYMMDDhhmm, YYYYMMDDhhmmss.
  * @param timestamp Wayback timestamp
- * @returns ISO8601 formatted timestamp, or empty string if invalid
+ * @returns {string} ISO8601 formatted timestamp, or empty string if invalid
  */
 export function waybackTimestampToISO(timestamp: string): string {
   const value = timestamp.trim();
@@ -94,49 +140,36 @@ export function waybackTimestampToISO(timestamp: string): string {
     return "";
   }
 
-  const month = value.length >= 6 ? value.slice(4, 6) : "01";
-  const day = value.length >= 8 ? value.slice(6, 8) : "01";
-  const hour = value.length >= 10 ? value.slice(8, 10) : "00";
-  const minute = value.length >= 12 ? value.slice(10, 12) : "00";
-  const second = value.length >= 14 ? value.slice(12, 14) : "00";
+  const parts = waybackDateParts(value);
+  const numbers = {
+    year: Number.parseInt(parts.year, 10),
+    month: Number.parseInt(parts.month, 10),
+    day: Number.parseInt(parts.day, 10),
+    hour: Number.parseInt(parts.hour, 10),
+    minute: Number.parseInt(parts.minute, 10),
+    second: Number.parseInt(parts.second, 10),
+  };
+  if (!validWaybackDateParts(numbers)) return "";
 
-  const yearNum = Number.parseInt(value.slice(0, 4), 10);
-  const monthNum = Number.parseInt(month, 10);
-  const dayNum = Number.parseInt(day, 10);
-  const hourNum = Number.parseInt(hour, 10);
-  const minuteNum = Number.parseInt(minute, 10);
-  const secondNum = Number.parseInt(second, 10);
-
-  if (
-    monthNum < 1 ||
-    monthNum > 12 ||
-    dayNum < 1 ||
-    dayNum > 31 ||
-    hourNum > 23 ||
-    minuteNum > 59 ||
-    secondNum > 59
-  ) {
-    return "";
-  }
-
-  const iso = `${value.slice(0, 4)}-${month}-${day}T${hour}:${minute}:${second}Z`;
-  const parsed = new Date(Date.UTC(yearNum, monthNum - 1, dayNum, hourNum, minuteNum, secondNum));
-  const isSameDateParts =
-    parsed.getUTCFullYear() === yearNum &&
-    parsed.getUTCMonth() + 1 === monthNum &&
-    parsed.getUTCDate() === dayNum &&
-    parsed.getUTCHours() === hourNum &&
-    parsed.getUTCMinutes() === minuteNum &&
-    parsed.getUTCSeconds() === secondNum;
-
-  return isSameDateParts ? iso : "";
+  const iso = `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}Z`;
+  const parsed = new Date(
+    Date.UTC(
+      numbers.year,
+      numbers.month - 1,
+      numbers.day,
+      numbers.hour,
+      numbers.minute,
+      numbers.second,
+    ),
+  );
+  return sameUtcDate(parsed, numbers) ? iso : "";
 }
 
 /**
  * Normalizes a domain string for search queries
  * @param domain The domain or URL to normalize
  * @param appendWildcard Whether a bare host should use prefix matching
- * @returns Normalized domain string
+ * @returns {string} Normalized domain string
  */
 export function normalizeDomain(domain: string, appendWildcard = true): string {
   // Normalize domain input using ufo
@@ -158,16 +191,16 @@ export function normalizeDomain(domain: string, appendWildcard = true): string {
  * @param pages Array of archived pages
  * @param source Source identifier for the provider
  * @param metadata Additional metadata to include
- * @returns Standardized ArchiveResponse object
+ * @returns {ArchiveResponse} Standardized ArchiveResponse object
  */
 export function createSuccessResponse(
-  pages: ArchivedPage[],
+  pages: readonly ArchivedPage[],
   source: string,
-  metadata: Record<string, unknown> = {},
+  metadata: Readonly<Record<string, unknown>> = {},
 ): ArchiveResponse {
   return {
     success: true,
-    pages,
+    pages: [...pages],
     _meta: {
       source,
       provider: source,
@@ -185,11 +218,14 @@ export function createSuccessResponse(
  * @param reason - Human-readable explanation of why the operation is unsupported.
  * @param source - Provider slug (mirrored to `_meta.source` and `_meta.provider`).
  * @param metadata - Extra fields merged into `_meta`.
+
+ *
+ * @returns {ArchiveResponse} The operation result.
  */
 export function createUnsupportedResponse(
   reason: string,
   source: string,
-  metadata: Record<string, unknown> = {},
+  metadata: Readonly<Record<string, unknown>> = {},
 ): ArchiveResponse {
   return {
     success: false,
@@ -209,12 +245,12 @@ export function createUnsupportedResponse(
  * @param error Error object, message, or unknown value
  * @param source Source identifier for the provider
  * @param metadata Additional metadata to include
- * @returns Standardized ArchiveResponse error object
+ * @returns {ArchiveResponse} Standardized ArchiveResponse error object
  */
 export function createErrorResponse(
   error: unknown,
   source: string,
-  metadata: Record<string, unknown> = {},
+  metadata: Readonly<Record<string, unknown>> = {},
 ): ArchiveResponse {
   return {
     success: false,
@@ -232,6 +268,10 @@ export function createErrorResponse(
 
 /**
  * Reduces a thrown value of unknown shape to one message.
+
+ *
+ * @param error - Error.
+ * @returns {string} The resulting string.
  */
 export function toErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
@@ -245,11 +285,14 @@ export function toErrorMessage(error: unknown): string {
  * @param content - The capture that was read
  * @param source - Provider slug (mirrored to `_meta.source` and `_meta.provider`)
  * @param metadata - Extra fields merged into `_meta`
+
+ *
+ * @returns {ArchiveContentResponse} The operation result.
  */
 export function createContentResponse(
   content: ArchivedContent,
   source: string,
-  metadata: Record<string, unknown> = {},
+  metadata: Readonly<Record<string, unknown>> = {},
 ): ArchiveContentResponse {
   return {
     success: true,
@@ -270,11 +313,14 @@ export function createContentResponse(
  * @param reason - Human-readable explanation of why the operation is unsupported
  * @param source - Provider slug
  * @param metadata - Extra fields merged into `_meta`
+
+ *
+ * @returns {ArchiveContentResponse} The operation result.
  */
 export function createUnsupportedContentResponse(
   reason: string,
   source: string,
-  metadata: Record<string, unknown> = {},
+  metadata: Readonly<Record<string, unknown>> = {},
 ): ArchiveContentResponse {
   return {
     success: false,
@@ -294,11 +340,14 @@ export function createUnsupportedContentResponse(
  * @param error - Error object, message, or unknown value
  * @param source - Provider slug
  * @param metadata - Extra fields merged into `_meta`
+
+ *
+ * @returns {ArchiveContentResponse} The operation result.
  */
 export function createContentErrorResponse(
   error: unknown,
   source: string,
-  metadata: Record<string, unknown> = {},
+  metadata: Readonly<Record<string, unknown>> = {},
 ): ArchiveContentResponse {
   return {
     success: false,
@@ -313,17 +362,25 @@ export function createContentErrorResponse(
   };
 }
 
+function requestLabel(request: unknown): string {
+  if (typeof request === "string") return request;
+  if (typeof request === "object" && request !== null && "url" in request) {
+    return typeof request.url === "string" ? request.url : "<request>";
+  }
+  return "<request>";
+}
+
 /**
  * Creates common fetch options with standard defaults
  * @param baseURL Base URL for the API
  * @param params Query parameters
  * @param options Additional options
- * @returns FetchOptions object
+ * @returns {Promise<FetchOptions>} FetchOptions object
  */
 export async function createFetchOptions(
   baseURL: string,
-  params: Record<string, any> = {},
-  options: Partial<FetchOptions & ArchiveOptions> = {},
+  params: Readonly<Record<string, unknown>> = {},
+  options: FetchOptions & ArchiveOptions = {},
 ): Promise<FetchOptions> {
   const config = await getConfig();
 
@@ -338,7 +395,7 @@ export async function createFetchOptions(
     retryStatusCodes: [408, 409, 425, 429, 500, 502, 503, 504], // Standard retry status codes
     onResponseError: ({ request, response, options }) => {
       consola.error(
-        `[fetch error] ${options.method} ${request} failed with status ${response.status}`,
+        `[fetch error] ${options.method} ${requestLabel(request)} failed with status ${response.status}`,
       );
     },
     ...options,
@@ -349,7 +406,7 @@ export async function createFetchOptions(
  * Merges initial options with request options, preferring request options
  * @param initOptions Initial options provided during provider creation
  * @param reqOptions Request-specific options
- * @returns Merged options object
+ * @returns {Promise<T>} Merged options object
  */
 export async function mergeOptions<T extends ArchiveOptions>(
   initOptions: Partial<T> = {},
@@ -379,13 +436,13 @@ export async function mergeOptions<T extends ArchiveOptions>(
  * @param snapshotBaseUrl Base URL for snapshot (including path segment).
  * @param providerSlug Provider identifier used for metadata typing.
  * @param options Performance options for processing.
- * @returns Array of ArchivedPage objects.
+ * @returns {Promise<ArchivedPage[]>} Array of ArchivedPage objects.
  */
 export async function mapCdxRows(
-  dataRows: string[][],
+  dataRows: readonly (readonly string[])[],
   snapshotBaseUrl: string,
   providerSlug = "wayback",
-  options: ArchiveOptions = {},
+  options: Readonly<ArchiveOptions> = {},
 ): Promise<ArchivedPage[]> {
   const config = await getConfig();
 
@@ -413,7 +470,7 @@ export async function mapCdxRows(
   return results;
 
   // Helper function to convert a row to an ArchivedPage
-  function rowToArchivedPage([rawUrl, rawTimestamp, rawStatus]: string[]):
+  function rowToArchivedPage([rawUrl, rawTimestamp, rawStatus]: readonly string[]):
     | ArchivedPage
     | undefined {
     const originalUrl = cleanDoubleSlashes(rawUrl ?? "");

--- a/test/_matchers.ts
+++ b/test/_matchers.ts
@@ -1,0 +1,46 @@
+import { expect } from "vitest";
+
+/**
+ * Keeps Vitest's `any`-typed asymmetric matcher behind an `unknown` boundary.
+ *
+ * @param expected - Partial shape the received value must contain.
+ * @returns {unknown} An opaque asymmetric matcher accepted by `expect`.
+ */
+export function objectContaining<T>(expected: T): unknown {
+  return expect.objectContaining(expected);
+}
+
+/**
+ * Exposes Vitest's constructor matcher without leaking its `any` return type.
+ *
+ * @param constructor - Constructor accepted by Vitest.
+ * @returns {unknown} An opaque asymmetric matcher.
+ */
+export function anyValue(constructor: unknown): unknown {
+  return expect.any(constructor);
+}
+
+/**
+ * Exposes Vitest's substring matcher without leaking its `any` return type.
+ *
+ * @param expected - Substring the received string must contain.
+ * @returns {unknown} An opaque asymmetric matcher.
+ */
+export function stringContaining(expected: string): unknown {
+  return expect.stringContaining(expected);
+}
+
+/**
+ * Reconstructs the range sentence from numeric TypeBox schema fields.
+ *
+ * @param parameter - JSON Schema parameter definition.
+ * @returns {string} The range fragment emitted by the tool schema.
+ */
+export function rangeDescription(parameter: Readonly<Record<string, unknown>> | undefined): string {
+  const minimum = parameter?.["minimum"];
+  const maximum = parameter?.["maximum"];
+  if (typeof minimum !== "number" || typeof maximum !== "number") {
+    throw new TypeError("Expected numeric minimum and maximum schema fields");
+  }
+  return `accepted range: ${minimum}-${maximum}`;
+}

--- a/test/archive-it.test.ts
+++ b/test/archive-it.test.ts
@@ -1,3 +1,4 @@
+import { objectContaining } from "./_matchers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { $fetch } from "ofetch";
 import { createArchive, resetConfig, storage } from "../src";
@@ -46,8 +47,8 @@ describe("Archive-It", () => {
     expect(result.success).toBe(true);
     expect($fetch).toHaveBeenCalledWith(
       "/4399/timemap/cdx",
-      expect.objectContaining({
-        params: expect.objectContaining({ from: "20190301", to: "201906" }),
+      objectContaining({
+        params: objectContaining({ from: "20190301", to: "201906" }),
       }),
     );
   });
@@ -78,10 +79,10 @@ describe("Archive-It", () => {
     expect(result._meta).toMatchObject({ source: "archive-it", collection: "4399" });
     expect($fetch).toHaveBeenCalledWith(
       "/4399/timemap/cdx",
-      expect.objectContaining({
+      objectContaining({
         baseURL: "https://wayback.archive-it.org",
         responseType: "text",
-        params: expect.objectContaining({
+        params: objectContaining({
           url: "example.com/*",
           fl: "original,timestamp,statuscode",
           limit: "2",
@@ -106,8 +107,8 @@ describe("Archive-It", () => {
 
     expect($fetch).toHaveBeenCalledWith(
       "/4399/timemap/cdx",
-      expect.objectContaining({
-        params: expect.objectContaining({
+      objectContaining({
+        params: objectContaining({
           url: "example.com/page",
           collapse: "timestamp:10",
           filter: "statuscode:200",

--- a/test/archive-today.test.ts
+++ b/test/archive-today.test.ts
@@ -1,3 +1,4 @@
+import { objectContaining } from "./_matchers";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { $fetch } from "ofetch";
 import { createArchive as createArchiveClient, resetConfig, storage } from "../src";
@@ -43,7 +44,7 @@ describe("archive.today", () => {
     // Verify API call
     expect($fetch).toHaveBeenCalledWith(
       "/timemap/http://example.com",
-      expect.objectContaining({
+      objectContaining({
         baseURL: "https://archive.is",
         signal: controller.signal,
         responseType: "text",

--- a/test/base-provider.test.ts
+++ b/test/base-provider.test.ts
@@ -6,10 +6,7 @@ class ArrowProvider extends BaseProvider {
   readonly name = "Arrow provider";
   readonly slug = "arrow";
 
-  snapshots = async (
-    _domain: string,
-    _options?: ArchiveOptions,
-  ): Promise<ArchiveResponse> => ({
+  snapshots = async (_domain: string, _options?: ArchiveOptions): Promise<ArchiveResponse> => ({
     success: true,
     pages: [],
   });

--- a/test/base-provider.test.ts
+++ b/test/base-provider.test.ts
@@ -6,7 +6,10 @@ class ArrowProvider extends BaseProvider {
   readonly name = "Arrow provider";
   readonly slug = "arrow";
 
-  snapshots = async (_domain: string, _options?: ArchiveOptions): Promise<ArchiveResponse> => ({
+  snapshots = async (
+    _domain: string,
+    _options?: Readonly<ArchiveOptions>,
+  ): Promise<ArchiveResponse> => ({
     success: true,
     pages: [],
   });

--- a/test/commoncrawl.test.ts
+++ b/test/commoncrawl.test.ts
@@ -1,3 +1,4 @@
+import { objectContaining } from "./_matchers";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { $fetch } from "ofetch";
 import { createArchive, resetConfig, storage } from "../src";
@@ -69,19 +70,39 @@ describe("Common Crawl", () => {
     expect($fetch).toHaveBeenNthCalledWith(
       1,
       "/collinfo.json",
-      expect.objectContaining({ baseURL: "https://index.commoncrawl.org" }),
+      objectContaining({ baseURL: "https://index.commoncrawl.org" }),
     );
     expect($fetch).toHaveBeenNthCalledWith(
       2,
       "/CC-MAIN-2023-50-index",
-      expect.objectContaining({
+      objectContaining({
         baseURL: "https://index.commoncrawl.org",
         method: "GET",
-        params: expect.objectContaining({
+        params: objectContaining({
           url: "example.com/*",
           output: "json",
         }),
       }),
+    );
+  });
+
+  it("uses the alternate CDX field when the primary field is empty", async () => {
+    vi.mocked($fetch)
+      .mockResolvedValueOnce([
+        {
+          "cdx-api": "",
+          cdxApi: "https://index.commoncrawl.org/CC-MAIN-2024-10-index",
+        },
+      ])
+      .mockResolvedValueOnce("");
+
+    const result = await createArchive(createCommonCrawl()).snapshots("example.com");
+
+    expect(result.success).toBe(true);
+    expect($fetch).toHaveBeenNthCalledWith(
+      2,
+      "/CC-MAIN-2024-10-index",
+      objectContaining({ baseURL: "https://index.commoncrawl.org" }),
     );
   });
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,3 +1,4 @@
+import { anyValue, objectContaining } from "./_matchers";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { getConfig, resolveConfig, resetConfig } from "../src/config";
 import { loadConfig } from "c12";
@@ -42,10 +43,10 @@ describe("Config", () => {
     // Assert
     expect(config).toEqual(defaultMockConfig);
     expect(mockedLoadConfig).toHaveBeenCalledWith(
-      expect.objectContaining({
+      objectContaining({
         name: "archives",
-        defaults: expect.any(Object),
-        envName: expect.any(String),
+        defaults: anyValue(Object),
+        envName: anyValue(String),
         rcFile: ".archives",
         packageJson: true,
       }),
@@ -146,9 +147,9 @@ describe("Config", () => {
 
     // Assert
     expect(mockedLoadConfig).toHaveBeenCalledWith(
-      expect.objectContaining({
+      objectContaining({
         name: "archives",
-        defaults: expect.any(Object),
+        defaults: anyValue(Object),
         envName: "production",
         cwd: "/custom/path",
         configFile: "custom.config.ts",
@@ -168,7 +169,7 @@ describe("Config", () => {
 
     // Assert
     expect(mockedLoadConfig).toHaveBeenCalledWith(
-      expect.objectContaining({
+      objectContaining({
         envName: "test",
       }),
     );

--- a/test/conifer.test.ts
+++ b/test/conifer.test.ts
@@ -1,3 +1,4 @@
+import { objectContaining } from "./_matchers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { $fetch } from "ofetch";
 import { createArchive, resetConfig, storage } from "../src";
@@ -60,7 +61,7 @@ describe("Conifer", () => {
     });
     expect($fetch).toHaveBeenCalledWith(
       "/api/v1/url_search",
-      expect.objectContaining({
+      objectContaining({
         baseURL: "https://conifer.rhizome.org",
         params: {
           user: "imamuseum",
@@ -82,7 +83,7 @@ describe("Conifer", () => {
 
     expect($fetch).toHaveBeenCalledWith(
       "/api/v1/url_search",
-      expect.objectContaining({ signal: controller.signal }),
+      objectContaining({ signal: controller.signal }),
     );
   });
 

--- a/test/content.test.ts
+++ b/test/content.test.ts
@@ -1,3 +1,4 @@
+import { objectContaining } from "./_matchers";
 import { gzipSync } from "node:zlib";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { $fetch, type FetchResponse } from "ofetch";
@@ -16,15 +17,20 @@ vi.mock("ofetch", () => {
 });
 
 const fetchMock = vi.mocked($fetch);
-const rawMock = vi.mocked($fetch.raw);
+/* oxlint-disable-next-line typescript/unbound-method -- ofetch.raw is a standalone callable and the mock has no receiver state. */
+const rawMock = fetchMock.raw;
 
-function cdxRows(rows: string[][]): string[][] {
+function cdxRows(rows: readonly (readonly string[])[]): string[][] {
   return [["original", "timestamp", "statuscode"], ...rows];
 }
 
 function rawResponse(
   body: string | Uint8Array | ReadableStream<Uint8Array>,
-  init: { url?: string; status?: number; headers?: Record<string, string> } = {},
+  init: Readonly<{
+    url?: string;
+    status?: number;
+    headers?: Readonly<Record<string, string>>;
+  }> = {},
 ) {
   // SAFETY: the helpers under test read only these four fields of a response.
   return {
@@ -35,7 +41,7 @@ function rawResponse(
   } as unknown as FetchResponse<unknown>;
 }
 
-function textStream(chunks: string[]): ReadableStream<Uint8Array> {
+function textStream(chunks: readonly string[]): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
   return new ReadableStream<Uint8Array>({
     start(controller) {
@@ -45,7 +51,7 @@ function textStream(chunks: string[]): ReadableStream<Uint8Array> {
   });
 }
 
-/** A provider stub with only the methods a given test needs. */
+/* A provider stub with only the methods a given test needs. */
 function stubProvider(slug: string, content?: ArchiveProvider["content"]): ArchiveProvider {
   return {
     name: slug,
@@ -102,7 +108,7 @@ describe("wayback content", () => {
     );
     expect(rawMock.mock.calls[0][0]).toBe("/web/20200202000000id_/https://example.com/");
     expect(fetchMock.mock.calls[0][1]).toMatchObject({
-      params: expect.objectContaining({ limit: "-5", url: "example.com" }),
+      params: objectContaining({ limit: "-5", url: "example.com" }),
     });
   });
 
@@ -172,7 +178,7 @@ describe("wayback content", () => {
     });
 
     expect(fetchMock.mock.calls[0][1]).toMatchObject({
-      params: expect.objectContaining({ to: "20190302043000" }),
+      params: objectContaining({ to: "20190302043000" }),
     });
   });
 
@@ -235,7 +241,7 @@ describe("wayback content", () => {
     });
 
     expect(fetchMock.mock.calls[0][1]).toMatchObject({
-      params: expect.objectContaining({ to: "20190301" }),
+      params: objectContaining({ to: "20190301" }),
     });
     expect(response.content?.timestamp).toBe("2019-02-28T12:00:00Z");
   });
@@ -268,7 +274,7 @@ describe("wayback content", () => {
 
     // 23:30 in -05:00 is 04:30 the next day in UTC, which is how archives index it.
     expect(fetchMock.mock.calls[0][1]).toMatchObject({
-      params: expect.objectContaining({ to: "20190302043000" }),
+      params: objectContaining({ to: "20190302043000" }),
     });
   });
 
@@ -281,7 +287,7 @@ describe("wayback content", () => {
     );
 
     expect(fetchMock.mock.calls[0][1]).toMatchObject({
-      params: expect.objectContaining({ url: "example.com/", to: "20190301120000" }),
+      params: objectContaining({ url: "example.com/", to: "20190301120000" }),
     });
     expect(response.success).toBe(true);
   });
@@ -418,7 +424,7 @@ describe("archive-it content", () => {
     await createArchive(createArchiveIt({ collection: 4399 })).content("example.com");
 
     expect(fetchMock.mock.calls[0][1]).toMatchObject({
-      params: expect.objectContaining({ sort: "reverse" }),
+      params: objectContaining({ sort: "reverse" }),
     });
   });
 
@@ -466,7 +472,7 @@ describe("archive-today content", () => {
     expect(response.content?.content).toContain("archived profile");
     expect(rawMock).toHaveBeenCalledWith(
       "/20210326214327/https://example.com",
-      expect.objectContaining({ baseURL: "http://archive.md" }),
+      objectContaining({ baseURL: "http://archive.md" }),
     );
   });
 
@@ -482,7 +488,7 @@ describe("archive-today content", () => {
 
     expect(rawMock).toHaveBeenCalledWith(
       "/20200606060606/https://example.com",
-      expect.objectContaining({ baseURL: "http://archive.md" }),
+      objectContaining({ baseURL: "http://archive.md" }),
     );
   });
 
@@ -502,7 +508,7 @@ describe("archive-today content", () => {
     expect(fetchMock).toHaveBeenCalledWith("/timemap/http://example.com", expect.anything());
     expect(rawMock).toHaveBeenCalledWith(
       "/20200606060606/https://example.com",
-      expect.objectContaining({ baseURL: "http://archive.md" }),
+      objectContaining({ baseURL: "http://archive.md" }),
     );
   });
 
@@ -633,7 +639,7 @@ describe("common crawl content", () => {
     );
 
     expect(fetchMock.mock.calls[0][1]).toMatchObject({
-      params: expect.objectContaining({ closest: "20240199999999", sort: "closest" }),
+      params: objectContaining({ closest: "20240199999999", sort: "closest" }),
     });
   });
 
@@ -849,8 +855,8 @@ describe("multi-provider content", () => {
     );
     await expect(archive.getContent("example.com")).rejects.toMatchObject({
       providers: [
-        expect.objectContaining({ provider: "conifer" }),
-        expect.objectContaining({ provider: "webcite" }),
+        objectContaining({ provider: "conifer" }),
+        objectContaining({ provider: "webcite" }),
       ],
     });
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,3 +1,4 @@
+import { objectContaining } from "./_matchers";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Archive, createArchive, UnsupportedOperationError, storage, resetConfig } from "../src";
 import createWayback from "../src/providers/wayback";
@@ -14,7 +15,7 @@ beforeEach(async () => {
 
 // --- helpers ---
 
-function successProvider(slug: string, pages: ArchivedPage[]): ArchiveProvider {
+function successProvider(slug: string, pages: readonly ArchivedPage[]): ArchiveProvider {
   return {
     name: slug,
     slug,
@@ -60,7 +61,7 @@ const samplePage = (slug: string): ArchivedPage => ({
   _meta: { provider: slug },
 });
 
-async function captureThrow(promise: Promise<unknown>): Promise<unknown> {
+async function captureThrow(promise: Readonly<Promise<unknown>>): Promise<unknown> {
   try {
     await promise;
   } catch (error) {
@@ -96,12 +97,13 @@ describe("createArchive", () => {
 
     expect(mockProvider.snapshots).toHaveBeenCalledWith(
       "example.com",
-      expect.objectContaining({ timeout: 10_000, limit: 100 }),
+      objectContaining({ timeout: 10_000, limit: 100 }),
     );
   });
 
   it("keeps snapshots callable when passed as a callback", async () => {
     const archive = createArchive(successProvider("callback", []), { cache: false });
+    /* oxlint-disable-next-line typescript/unbound-method -- extraction is the behavior under test; Archive binds this method. */
     const snapshots = archive.snapshots;
 
     await expect(snapshots("example.com")).resolves.toMatchObject({
@@ -149,7 +151,7 @@ describe("Archive.snapshots / window", () => {
     expect(response.pages.map((page) => page.timestamp)).toEqual(["2019-03-01T12:00:00Z"]);
     expect(provider.snapshots).toHaveBeenCalledWith(
       "example.com",
-      expect.objectContaining({ from: "20190101", to: "201906" }),
+      objectContaining({ from: "20190101", to: "201906" }),
     );
   });
 

--- a/test/mcp.test.ts
+++ b/test/mcp.test.ts
@@ -1,3 +1,4 @@
+import { objectContaining, rangeDescription } from "./_matchers";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -9,6 +10,14 @@ import type {
   ArchivedContent,
   ArchivedPage,
 } from "../src/types";
+
+type PageOverrides = Readonly<Omit<Partial<ArchivedPage>, "_meta">> & {
+  readonly _meta?: Readonly<ArchivedPage["_meta"]>;
+};
+
+type ContentOverrides = Readonly<Omit<Partial<ArchivedContent>, "_meta">> & {
+  readonly _meta?: Readonly<ArchivedContent["_meta"]>;
+};
 
 const providersMock = vi.hoisted(() => ({
   all: vi.fn(),
@@ -40,7 +49,7 @@ function text(content: unknown): string {
     .join("");
 }
 
-function page(overrides: Partial<ArchivedPage> = {}): ArchivedPage {
+function page(overrides: PageOverrides = {}): ArchivedPage {
   return {
     url: "https://example.com/",
     timestamp: "2024-01-02T03:04:05.000Z",
@@ -50,11 +59,11 @@ function page(overrides: Partial<ArchivedPage> = {}): ArchivedPage {
   };
 }
 
-function success(pages: ArchivedPage[], provider = "wayback"): ArchiveResponse {
-  return { success: true, pages, _meta: { source: provider, provider } };
+function success(pages: readonly ArchivedPage[], provider = "wayback"): ArchiveResponse {
+  return { success: true, pages: [...pages], _meta: { source: provider, provider } };
 }
 
-function capture(overrides: Partial<ArchivedContent> = {}): ArchiveContentResponse {
+function capture(overrides: ContentOverrides = {}): ArchiveContentResponse {
   return {
     success: true,
     content: {
@@ -72,9 +81,9 @@ function capture(overrides: Partial<ArchivedContent> = {}): ArchiveContentRespon
   };
 }
 
-/** Registers a fake provider whose `content()` resolves to `response`. */
+/* Registers a fake provider whose `content()` resolves to `response`. */
 function stubContentProvider(
-  factory: { mockResolvedValue(value: unknown): void },
+  factory: Readonly<{ mockResolvedValue(value: unknown): void }>,
   response: ArchiveContentResponse,
   slug = "wayback",
 ): void {
@@ -86,9 +95,9 @@ function stubContentProvider(
   });
 }
 
-/** Registers a fake provider whose `snapshots()` resolves to `response`. */
+/* Registers a fake provider whose `snapshots()` resolves to `response`. */
 function stubProvider(
-  factory: { mockResolvedValue(value: unknown): void },
+  factory: Readonly<{ mockResolvedValue(value: unknown): void }>,
   response: ArchiveResponse,
   slug = "wayback",
 ): void {
@@ -168,9 +177,7 @@ describe("archives MCP server", () => {
 
       for (const parameterName of parameterNames) {
         const parameter = properties[parameterName];
-        expect(parameter?.["description"]).toContain(
-          `accepted range: ${parameter?.["minimum"]}-${parameter?.["maximum"]}`,
-        );
+        expect(parameter?.["description"]).toContain(rangeDescription(parameter));
       }
     }
   });
@@ -267,7 +274,7 @@ describe("archives MCP server", () => {
   it("strips terminal control bytes a provider put in its snapshot data", async () => {
     stubProvider(
       providersMock.wayback,
-      success([page({ url: "https://example.com/\u001b[31mred\u0007" })]),
+      success([page({ url: "https://example.com/\u001B[31mred\u0007" })]),
     );
     const client = await connectTestClient();
 
@@ -278,7 +285,7 @@ describe("archives MCP server", () => {
 
     expect(text(response.content)).toContain("original: https://example.com/[31mred");
     // oxlint-disable-next-line no-control-regex -- The assertion is that no control byte survived.
-    expect(text(response.content)).not.toMatch(/[\u0000-\u0008\u001b]/u);
+    expect(text(response.content)).not.toMatch(/[\u0000-\u0008\u001B]/u);
   });
 
   it("reports providers that failed instead of counting only the survivors", async () => {
@@ -454,7 +461,7 @@ describe("archives MCP server", () => {
     });
 
     expect(providersMock.permacc).toHaveBeenCalledWith(
-      expect.objectContaining({ apiKey: "secret-key-value" }),
+      objectContaining({ apiKey: "secret-key-value" }),
     );
     expect(text(response.content)).not.toContain("secret-key-value");
   });

--- a/test/memento.test.ts
+++ b/test/memento.test.ts
@@ -1,6 +1,14 @@
+import { anyValue, objectContaining } from "./_matchers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { $fetch, type FetchResponse } from "ofetch";
-import { createArchive, MementoProvider, providers, resetConfig, storage } from "../src";
+import {
+  createArchive,
+  MementoProvider,
+  providers,
+  resetConfig,
+  storage,
+  type ArchiveContentResponse,
+} from "../src";
 import createMemento from "../src/providers/memento";
 
 vi.mock("ofetch", () => {
@@ -9,12 +17,17 @@ vi.mock("ofetch", () => {
 });
 
 const fetchMock = vi.mocked($fetch);
-const rawMock = vi.mocked($fetch.raw);
+/* oxlint-disable-next-line typescript/unbound-method -- ofetch.raw is a standalone callable and the mock has no receiver state. */
+const rawMock = fetchMock.raw;
 
-/** Builds only the response fields consumed by the provider's body reader. */
+/* Builds only the response fields consumed by the provider's body reader. */
 function rawResponse(
   body: string,
-  init: { url?: string; status?: number; headers?: Record<string, string> } = {},
+  init: Readonly<{
+    url?: string;
+    status?: number;
+    headers?: Readonly<Record<string, string>>;
+  }> = {},
 ) {
   return {
     status: init.status ?? 200,
@@ -22,6 +35,16 @@ function rawResponse(
     headers: new Headers(init.headers ?? {}),
     _data: body,
   } as unknown as FetchResponse<unknown>;
+}
+
+function expectProxiedCapture(response: ArchiveContentResponse): void {
+  expect(response.success).toBe(true);
+  expect(response.content?.content).toBe("proxied capture");
+  expect(response.content?.timestamp).toBe("2020-04-02T20:09:40Z");
+  expect(response.content?.snapshot).toContain("memgator.cs.odu.edu/memento/proxy/");
+  expect(response.content?._meta).not.toHaveProperty("archive");
+  expect(response.content?._meta).not.toHaveProperty("datetime");
+  expect(response.content?._meta.proxyFallback).toBe(true);
 }
 
 beforeEach(async () => {
@@ -100,7 +123,7 @@ describe("Memento aggregator", () => {
     ]);
     expect(fetchMock).toHaveBeenCalledWith(
       "/timemap/json/https%3A%2F%2Fexample.com%2F",
-      expect.objectContaining({
+      objectContaining({
         baseURL: "https://memgator.cs.odu.edu",
         signal: controller.signal,
         retry: 1,
@@ -129,7 +152,7 @@ describe("Memento aggregator", () => {
     expect(response.pages[0]?.url).toBe("http://www.example.com/");
     expect(fetchMock).toHaveBeenCalledWith(
       "/timemap/json/http%3A%2F%2Fexample.com",
-      expect.any(Object),
+      anyValue(Object),
     );
   });
 
@@ -253,13 +276,7 @@ describe("Memento aggregator", () => {
       cache: false,
     });
 
-    expect(response.success).toBe(true);
-    expect(response.content?.content).toBe("proxied capture");
-    expect(response.content?.timestamp).toBe("2020-04-02T20:09:40Z");
-    expect(response.content?.snapshot).toContain("memgator.cs.odu.edu/memento/proxy/");
-    expect(response.content?._meta).not.toHaveProperty("archive");
-    expect(response.content?._meta).not.toHaveProperty("datetime");
-    expect(response.content?._meta.proxyFallback).toBe(true);
+    expectProxiedCapture(response);
     expect(rawMock.mock.calls[0]?.[0]).toBe("/20200402195411id_/https://www.example.com/");
     expect(rawMock.mock.calls[0]?.[1]).toMatchObject({ baseURL: "https://vefsafn.is" });
     expect(rawMock.mock.calls[1]?.[0]).toBe(
@@ -380,7 +397,7 @@ describe("Memento aggregator", () => {
     expect(response.success).toBe(true);
     expect(fetchMock).toHaveBeenCalledWith(
       "/timemap/json/https%3A%2F%2Fexample.com%2F",
-      expect.any(Object),
+      anyValue(Object),
     );
     expect(rawMock.mock.calls[0]?.[0]).toBe("/wayback/20200402133000id_/https://example.com/");
   });

--- a/test/omp-extension.test.ts
+++ b/test/omp-extension.test.ts
@@ -1,3 +1,4 @@
+import { objectContaining, rangeDescription } from "./_matchers";
 import * as TypeBox from "@oh-my-pi/omptype/typebox";
 import { $fetch } from "ofetch";
 import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "@oh-my-pi/pi-coding-agent";
@@ -46,7 +47,7 @@ function registerExtension(): RegisteredExtension {
   return { label, tools, commands };
 }
 
-function requireTool(tools: Map<string, ToolDefinition>, name: string): ToolDefinition {
+function requireTool(tools: Readonly<Map<string, ToolDefinition>>, name: string): ToolDefinition {
   const tool = tools.get(name);
   if (!tool) throw new Error(`Tool not registered: ${name}`);
   return tool;
@@ -94,9 +95,7 @@ describe("archives OMP extension", () => {
 
     for (const parameterName of ["maxChars", "ttl", "timeout", "retries"]) {
       const parameter = properties[parameterName];
-      expect(parameter?.["description"]).toContain(
-        `accepted range: ${parameter?.["minimum"]}-${parameter?.["maximum"]}`,
-      );
+      expect(parameter?.["description"]).toContain(rangeDescription(parameter));
     }
     expect(accepts(tool, { target: "example.com" })).toBe(true);
     expect(accepts(tool, { target: "example.com", format: "text" })).toBe(true);
@@ -139,9 +138,7 @@ describe("archives OMP extension", () => {
       "retries",
     ]) {
       const parameter = properties[parameterName];
-      expect(parameter?.["description"]).toContain(
-        `accepted range: ${parameter?.["minimum"]}-${parameter?.["maximum"]}`,
-      );
+      expect(parameter?.["description"]).toContain(rangeDescription(parameter));
     }
     expect(accepts(tool, { target: "example.com", limit: MAX_LIMIT })).toBe(true);
     expect(accepts(tool, { target: "example.com", limit: MAX_LIMIT + 1 })).toBe(false);
@@ -173,8 +170,8 @@ describe("archives OMP extension", () => {
 
     expect($fetch).toHaveBeenCalledWith(
       "/cdx/search/cdx",
-      expect.objectContaining({
-        params: expect.objectContaining({ from: "20190301", to: "201906" }),
+      objectContaining({
+        params: objectContaining({ from: "20190301", to: "201906" }),
       }),
     );
   });
@@ -193,7 +190,7 @@ describe("archives OMP extension", () => {
 
     expect($fetch).toHaveBeenCalledWith(
       "/4399/timemap/cdx",
-      expect.objectContaining({ baseURL: "https://wayback.archive-it.org" }),
+      objectContaining({ baseURL: "https://wayback.archive-it.org" }),
     );
     expect(result.details).toMatchObject({
       provider: "archiveIt",
@@ -236,7 +233,7 @@ describe("archives OMP extension", () => {
 
     expect($fetch).toHaveBeenCalledWith(
       "/api/v1/url_search",
-      expect.objectContaining({
+      objectContaining({
         baseURL: "https://conifer.rhizome.org",
         params: { user: "user", coll: "collection", url: "example.com" },
       }),
@@ -274,7 +271,7 @@ describe("archives OMP extension", () => {
       fg: (_color: string, text: string) => text,
     } as unknown as RenderTheme;
     const component = renderCall(
-      { target: "safe\u001b]52;c;SGVsbG8=\u0007.example" },
+      { target: "safe\u001B]52;c;SGVsbG8=\u0007.example" },
       { expanded: false, isPartial: false },
       theme,
     );
@@ -283,7 +280,7 @@ describe("archives OMP extension", () => {
     expect(rendered).toContain("safe]52;c;SGVsbG8=.example");
     expect(rendered.split("\n")).toHaveLength(1);
     // oxlint-disable-next-line no-control-regex -- This assertion proves the terminal boundary.
-    expect(rendered).not.toMatch(/[\u0000-\u0008\u000b-\u001f\u007f-\u009f]/u);
+    expect(rendered).not.toMatch(/[\u0000-\u0008\u000B-\u001F\u007F-\u009F]/u);
   });
 
   /** A windowed call must not preview like a full-archive scan. */

--- a/test/permacc.test.ts
+++ b/test/permacc.test.ts
@@ -1,3 +1,4 @@
+import { objectContaining } from "./_matchers";
 import { $fetch } from "ofetch";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createArchive, resetConfig, storage } from "../src";
@@ -12,11 +13,11 @@ function permaResponse({
   guid = "ABC123",
   url = "https://example.com/",
   creationTimestamp = "2023-01-01T12:00:00Z",
-}: {
+}: Readonly<{
   guid?: string;
   url?: string;
   creationTimestamp?: string | null;
-} = {}) {
+}> = {}) {
   return {
     objects: [
       {
@@ -82,7 +83,7 @@ describe("Perma.cc Platform", () => {
     });
     expect($fetch).toHaveBeenCalledWith(
       "/v1/archives/",
-      expect.objectContaining({
+      objectContaining({
         baseURL: "https://api.perma.cc",
         headers: {
           Authorization: "ApiKey test_key",
@@ -105,8 +106,8 @@ describe("Perma.cc Platform", () => {
 
     expect($fetch).toHaveBeenCalledWith(
       "/v1/archives/",
-      expect.objectContaining({
-        params: expect.objectContaining({
+      objectContaining({
+        params: objectContaining({
           url: "http://example.com/Page?version=1",
         }),
       }),
@@ -120,8 +121,8 @@ describe("Perma.cc Platform", () => {
 
     expect($fetch).toHaveBeenCalledWith(
       "/v1/archives/",
-      expect.objectContaining({
-        params: expect.objectContaining({
+      objectContaining({
+        params: objectContaining({
           url: "https://localhost:8080/page",
         }),
       }),
@@ -139,8 +140,8 @@ describe("Perma.cc Platform", () => {
     expect(result.success).toBe(true);
     expect($fetch).toHaveBeenCalledWith(
       "/v1/archives/",
-      expect.objectContaining({
-        params: expect.objectContaining({ limit: 50 }),
+      objectContaining({
+        params: objectContaining({ limit: 50 }),
       }),
     );
   });
@@ -262,12 +263,8 @@ describe("Perma.cc Platform", () => {
     expect(first.pages[0].snapshot).toBe("https://perma.cc/FIRST");
     expect(second.pages[0].snapshot).toBe("https://perma.cc/SECOND");
     expect($fetch).toHaveBeenCalledTimes(2);
-    expect(vi.mocked($fetch).mock.calls[0][1]?.params).toEqual(
-      expect.objectContaining({ limit: 5 }),
-    );
-    expect(vi.mocked($fetch).mock.calls[1][1]?.params).toEqual(
-      expect.objectContaining({ limit: 10 }),
-    );
+    expect(vi.mocked($fetch).mock.calls[0][1]?.params).toEqual(objectContaining({ limit: 5 }));
+    expect(vi.mocked($fetch).mock.calls[1][1]?.params).toEqual(objectContaining({ limit: 10 }));
   });
 
   it("does not let URL text collide with an account cache partition", async () => {

--- a/test/pi-extension.test.ts
+++ b/test/pi-extension.test.ts
@@ -1,3 +1,4 @@
+import { objectContaining, rangeDescription, stringContaining } from "./_matchers";
 import type {
   AgentToolResult,
   ExtensionAPI,
@@ -75,16 +76,18 @@ vi.mock("../src/providers", () => ({
 
 type CommandDefinition = Parameters<ExtensionAPI["registerCommand"]>[1];
 
+type ToolRegistry = ReadonlyMap<string, ToolDefinition>;
+
 type CapturedRuntime = {
-  tools: Map<string, ToolDefinition>;
-  commands: Map<string, CommandDefinition>;
+  readonly tools: ToolRegistry;
+  readonly commands: ReadonlyMap<string, CommandDefinition>;
 };
 
 type ExecutableTool = {
   parameters: { properties?: Record<string, unknown> };
   execute: (
     toolCallId: string,
-    params: Record<string, unknown>,
+    params: Readonly<Record<string, unknown>>,
     signal: AbortSignal | undefined,
     onUpdate: undefined,
     ctx: ExtensionContext,
@@ -92,16 +95,15 @@ type ExecutableTool = {
 };
 
 function loadExtension(): CapturedRuntime {
-  const runtime: CapturedRuntime = {
-    tools: new Map(),
-    commands: new Map(),
-  };
+  const tools = new Map<string, ToolDefinition>();
+  const commands = new Map<string, CommandDefinition>();
+  const runtime: CapturedRuntime = { tools, commands };
   const pi = {
     registerTool(tool: ToolDefinition) {
-      runtime.tools.set(tool.name, tool);
+      tools.set(tool.name, tool);
     },
     registerCommand(name: string, command: CommandDefinition) {
-      runtime.commands.set(name, command);
+      commands.set(name, command);
     },
   } satisfies Partial<ExtensionAPI>;
 
@@ -109,10 +111,23 @@ function loadExtension(): CapturedRuntime {
   return runtime;
 }
 
-function getExecutableTool(runtime: CapturedRuntime, name: string): ExecutableTool {
-  const tool = runtime.tools.get(name);
+function getExecutableTool(
+  tools: ReadonlyMap<string, ToolDefinition>,
+  name: string,
+): ExecutableTool {
+  const tool = tools.get(name);
   expect(tool).toBeDefined();
   return tool as ExecutableTool;
+}
+
+function expectRangeDescriptions(
+  properties: Readonly<Record<string, Readonly<Record<string, unknown>>>>,
+  names: readonly string[],
+): void {
+  for (const name of names) {
+    const parameter = properties[name];
+    expect(parameter?.["description"]).toContain(rangeDescription(parameter));
+  }
 }
 
 const originalPermaccEnv = {
@@ -170,7 +185,7 @@ describe("Pi extension", () => {
   });
 
   it("declares the content schema the shared executors enforce", () => {
-    const tool = getExecutableTool(loadExtension(), "archives_content");
+    const tool = getExecutableTool(loadExtension().tools, "archives_content");
     const properties = tool.parameters.properties as Record<string, Record<string, unknown>>;
 
     expect(properties["provider"]?.["description"]).toBe(CONTENT_PROVIDER_HINT);
@@ -181,12 +196,7 @@ describe("Pi extension", () => {
       maximum: MAX_CONTENT_CHARS,
     });
     expect(properties["maxChars"]?.["description"]).toContain(`Defaults to ${DEFAULT_MAX_CHARS}`);
-    for (const parameterName of ["maxChars", "ttl", "timeout", "retries"]) {
-      const parameter = properties[parameterName];
-      expect(parameter?.["description"]).toContain(
-        `accepted range: ${parameter?.["minimum"]}-${parameter?.["maximum"]}`,
-      );
-    }
+    expectRangeDescriptions(properties, ["maxChars", "ttl", "timeout", "retries"]);
 
     const offeredFormats = (
       (properties["format"]?.["anyOf"] ?? []) as Array<{ const: string }>
@@ -209,7 +219,7 @@ describe("Pi extension", () => {
       },
       _meta: { source: "wayback", provider: "wayback" },
     } satisfies ArchiveContentResponse);
-    const tool = getExecutableTool(loadExtension(), "archives_content");
+    const tool = getExecutableTool(loadExtension().tools, "archives_content");
 
     const result = await tool.execute(
       "test",
@@ -229,12 +239,12 @@ describe("Pi extension", () => {
     expect(text).not.toContain("<h1>");
     expect(archivesMock.content).toHaveBeenCalledWith(
       "https://example.com/",
-      expect.objectContaining({ timestamp: "20190301" }),
+      objectContaining({ timestamp: "20190301" }),
     );
   });
 
   it("rejects a timestamp no archive could act on, before any network work", async () => {
-    const tool = getExecutableTool(loadExtension(), "archives_content");
+    const tool = getExecutableTool(loadExtension().tools, "archives_content");
 
     await expect(
       tool.execute(
@@ -250,7 +260,7 @@ describe("Pi extension", () => {
 
   it("stops an in-flight archive request when the tool is cancelled", async () => {
     archivesMock.snapshots.mockImplementation(
-      (_target: string, options: { signal?: AbortSignal }) =>
+      (_target: string, options: Readonly<{ signal?: AbortSignal }>) =>
         new Promise<ArchiveResponse>((_resolve, reject) => {
           const signal = options.signal;
           if (!signal) {
@@ -265,7 +275,7 @@ describe("Pi extension", () => {
           signal.addEventListener("abort", abort, { once: true });
         }),
     );
-    const tool = getExecutableTool(loadExtension(), "archives");
+    const tool = getExecutableTool(loadExtension().tools, "archives");
     const controller = new AbortController();
 
     const execution = tool.execute(
@@ -279,7 +289,7 @@ describe("Pi extension", () => {
       () =>
         expect(archivesMock.snapshots).toHaveBeenCalledWith(
           "example.com",
-          expect.objectContaining({ signal: controller.signal }),
+          objectContaining({ signal: controller.signal }),
         ),
       { timeout: 100 },
     );
@@ -288,33 +298,28 @@ describe("Pi extension", () => {
     const result = await execution;
     expect(result.isError).toBe(true);
     expect(result.content[0]).toEqual(
-      expect.objectContaining({ type: "text", text: expect.stringContaining("cancelled by test") }),
+      objectContaining({ type: "text", text: stringContaining("cancelled by test") }),
     );
     expect((result.details as { options: Record<string, unknown> }).options).not.toHaveProperty(
       "signal",
     );
   });
   it("declares the schema bounds the shared executors enforce", () => {
-    const tool = getExecutableTool(loadExtension(), "archives");
+    const tool = getExecutableTool(loadExtension().tools, "archives");
     const properties = tool.parameters.properties as Record<string, Record<string, unknown>>;
 
     // The parameters are declared before the executors can be loaded, so the
     // restated metadata has to match what src/tool-operations actually applies.
     expect(properties["limit"]).toMatchObject({ minimum: 1, maximum: MAX_LIMIT });
     expect(properties["limit"]?.["description"]).toContain(`Defaults to ${DEFAULT_LIMIT}`);
-    for (const parameterName of [
+    expectRangeDescriptions(properties, [
       "limit",
       "ttl",
       "concurrency",
       "batchSize",
       "timeout",
       "retries",
-    ]) {
-      const parameter = properties[parameterName];
-      expect(parameter?.["description"]).toContain(
-        `accepted range: ${parameter?.["minimum"]}-${parameter?.["maximum"]}`,
-      );
-    }
+    ]);
     expect(properties["provider"]?.["description"]).toBe(PROVIDER_HINT);
     expect(properties["from"]?.["description"]).toBe(SNAPSHOT_FROM_HINT);
     expect(properties["to"]?.["description"]).toBe(SNAPSHOT_TO_HINT);
@@ -331,7 +336,7 @@ describe("Pi extension", () => {
       pages: [],
       _meta: { source: "wayback", provider: "wayback" },
     } satisfies ArchiveResponse);
-    const tool = getExecutableTool(loadExtension(), "archives");
+    const tool = getExecutableTool(loadExtension().tools, "archives");
 
     await tool.execute(
       "test",
@@ -343,13 +348,13 @@ describe("Pi extension", () => {
 
     expect(archivesMock.snapshots).toHaveBeenCalledWith(
       "example.com",
-      expect.objectContaining({ from: "20190301", to: "201906" }),
+      objectContaining({ from: "20190301", to: "201906" }),
     );
   });
 
   it("does not expose arbitrary API-key or environment-variable parameters", () => {
     const runtime = loadExtension();
-    const tool = getExecutableTool(runtime, "archives");
+    const tool = getExecutableTool(runtime.tools, "archives");
 
     expect(Object.keys(tool.parameters.properties ?? {})).not.toContain("apiKey");
     expect(Object.keys(tool.parameters.properties ?? {})).not.toContain("apiKeyEnv");
@@ -358,7 +363,7 @@ describe("Pi extension", () => {
   it("reports Perma.cc key presence without returning the secret value", async () => {
     process.env["PERMA_CC_API_KEY"] = "super-secret-test-key";
     const runtime = loadExtension();
-    const tool = getExecutableTool(runtime, "archives_providers");
+    const tool = getExecutableTool(runtime.tools, "archives_providers");
 
     const result = await tool.execute("test", {}, undefined, undefined, {} as ExtensionContext);
     const text = result.content.map((item) => (item.type === "text" ? item.text : "")).join("\n");
@@ -375,7 +380,7 @@ describe("Pi extension", () => {
       pages: [],
       _meta: { source: "permacc", provider: "permacc" },
     } satisfies ArchiveResponse);
-    const tool = getExecutableTool(loadExtension(), "archives");
+    const tool = getExecutableTool(loadExtension().tools, "archives");
 
     const result = await tool.execute(
       "test",
@@ -393,7 +398,7 @@ describe("Pi extension", () => {
   });
 
   it("rejects a fractional limit that would reach the CDX query verbatim", async () => {
-    const tool = getExecutableTool(loadExtension(), "archives");
+    const tool = getExecutableTool(loadExtension().tools, "archives");
     const properties = tool.parameters.properties as Record<string, Record<string, unknown>>;
     expect(properties["limit"]?.["type"]).toBe("integer");
     expect(properties["target"]).toMatchObject({ minLength: 1 });
@@ -416,7 +421,7 @@ describe("Pi extension", () => {
     delete process.env["PERMA_CC_API_KEY"];
     delete process.env["PERMACC_API_KEY"];
     const runtime = loadExtension();
-    const tool = getExecutableTool(runtime, "archives");
+    const tool = getExecutableTool(runtime.tools, "archives");
 
     await expect(
       tool.execute(
@@ -442,7 +447,7 @@ describe("Pi extension", () => {
       pages: [],
       _meta: { source: "archive-it", provider: "archive-it" },
     } satisfies ArchiveResponse);
-    const tool = getExecutableTool(loadExtension(), "archives");
+    const tool = getExecutableTool(loadExtension().tools, "archives");
 
     await tool.execute(
       "test",
@@ -452,13 +457,11 @@ describe("Pi extension", () => {
       {} as ExtensionContext,
     );
 
-    expect(archivesMock.archiveIt).toHaveBeenCalledWith(
-      expect.objectContaining({ collection: "4399" }),
-    );
+    expect(archivesMock.archiveIt).toHaveBeenCalledWith(objectContaining({ collection: "4399" }));
   });
 
   it("rejects Archive-It requests without a collection", async () => {
-    const tool = getExecutableTool(loadExtension(), "archives");
+    const tool = getExecutableTool(loadExtension().tools, "archives");
 
     await expect(
       tool.execute(
@@ -483,7 +486,7 @@ describe("Pi extension", () => {
       pages: [],
       _meta: { source: "conifer", provider: "conifer" },
     } satisfies ArchiveResponse);
-    const tool = getExecutableTool(loadExtension(), "archives");
+    const tool = getExecutableTool(loadExtension().tools, "archives");
 
     await tool.execute(
       "test",
@@ -499,12 +502,12 @@ describe("Pi extension", () => {
     );
 
     expect(archivesMock.conifer).toHaveBeenCalledWith(
-      expect.objectContaining({ user: "user", collection: "collection" }),
+      objectContaining({ user: "user", collection: "collection" }),
     );
   });
 
   it("rejects Conifer requests without a user", async () => {
-    const tool = getExecutableTool(loadExtension(), "archives");
+    const tool = getExecutableTool(loadExtension().tools, "archives");
 
     await expect(
       tool.execute(

--- a/test/provider-lazy-loading.test.ts
+++ b/test/provider-lazy-loading.test.ts
@@ -1,13 +1,23 @@
 import { describe, expect, it } from "vitest";
 import { createRetryableLazyImport } from "../src/providers/_lazy-import";
 
+function deferred<T>() {
+  let resolve = (_value: T): void => {
+    throw new Error("Deferred promise was not initialized");
+  };
+  const promise = new Promise<T>((fulfill) => {
+    resolve = fulfill;
+  });
+  return { promise, resolve };
+}
+
 describe("provider lazy loading", () => {
   it("shares one in-flight module load across concurrent calls", async () => {
-    const deferred = Promise.withResolvers<{ readonly value: string }>();
+    const pending = deferred<{ readonly value: string }>();
     let attempts = 0;
     const load = createRetryableLazyImport(() => {
       attempts += 1;
-      return deferred.promise;
+      return pending.promise;
     });
 
     const first = load();
@@ -16,7 +26,7 @@ describe("provider lazy loading", () => {
     expect(attempts).toBe(1);
     expect(first).toBe(second);
 
-    deferred.resolve({ value: "loaded" });
+    pending.resolve({ value: "loaded" });
     await expect(Promise.all([first, second])).resolves.toEqual([
       { value: "loaded" },
       { value: "loaded" },

--- a/test/wayback.test.ts
+++ b/test/wayback.test.ts
@@ -1,3 +1,4 @@
+import { objectContaining } from "./_matchers";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { $fetch } from "ofetch";
 import { createArchive, resetConfig, storage } from "../src";
@@ -46,7 +47,7 @@ describe("wayback machine", () => {
     expect(result.pages[1]._meta.status).toBe(200);
     expect($fetch).toHaveBeenCalledWith(
       "/cdx/search/cdx",
-      expect.objectContaining({
+      objectContaining({
         baseURL: "https://web.archive.org",
         signal: controller.signal,
         method: "GET",
@@ -56,6 +57,7 @@ describe("wayback machine", () => {
 
   it("keeps snapshots callable when passed as a callback", async () => {
     vi.mocked($fetch).mockResolvedValueOnce([["original", "timestamp", "statuscode"]]);
+    /* oxlint-disable-next-line typescript/unbound-method -- extraction is the behavior under test; BaseProvider binds this method. */
     const snapshots = createWayback().snapshots;
 
     const result = await snapshots("example.com");
@@ -91,8 +93,8 @@ describe("wayback machine", () => {
     expect(result.success).toBe(true);
     expect($fetch).toHaveBeenCalledWith(
       "/cdx/search/cdx",
-      expect.objectContaining({
-        params: expect.objectContaining({
+      objectContaining({
+        params: objectContaining({
           collapse: "digest",
           filter: "statuscode:200",
           limit: "25",
@@ -110,8 +112,8 @@ describe("wayback machine", () => {
     expect(result.success).toBe(true);
     expect($fetch).toHaveBeenCalledWith(
       "/cdx/search/cdx",
-      expect.objectContaining({
-        params: expect.objectContaining({ from: "20190301", to: "201906" }),
+      objectContaining({
+        params: objectContaining({ from: "20190301", to: "201906" }),
       }),
     );
   });
@@ -132,8 +134,8 @@ describe("wayback machine", () => {
     expect(result.success).toBe(true);
     expect($fetch).toHaveBeenCalledWith(
       "/cdx/search/cdx",
-      expect.objectContaining({
-        params: expect.objectContaining({ from: "20190301", to: "201906" }),
+      objectContaining({
+        params: objectContaining({ from: "20190301", to: "201906" }),
       }),
     );
   });
@@ -151,8 +153,8 @@ describe("wayback machine", () => {
     expect(result.success).toBe(true);
     expect($fetch).toHaveBeenCalledWith(
       "/cdx/search/cdx",
-      expect.objectContaining({
-        params: expect.objectContaining({ from: "20190301" }),
+      objectContaining({
+        params: objectContaining({ from: "20190301" }),
       }),
     );
   });


### PR DESCRIPTION
A green lint run was meaningless here. Archives only loaded an empty local ruleset. `@agntn/ox` turns on the actual type-aware policy, and the violations are fixed without freezing public options or burying the diff under formatter churn.