### PR TITLE
fix: remove the fake Common Crawl latest index

### DIFF
--- a/src/providers/commoncrawl.ts
+++ b/src/providers/commoncrawl.ts
@@ -400,33 +400,25 @@ export class CommonCrawlProvider extends BaseProvider<CommonCrawlOptions> {
     if (configured && configured !== "CC-MAIN-latest") {
       return { collectionName: configured, indexName: indexName(configured) };
     }
-    return (
-      (await this.fetchLatestIndex(options)) ?? {
-        collectionName: "CC-MAIN-latest",
-        indexName: indexName("CC-MAIN-latest"),
-      }
-    );
+    return this.fetchLatestIndex(options);
   }
 
   private async fetchLatestIndex(
     options: Readonly<Partial<CommonCrawlOptions>>,
-  ): Promise<CrawlIndex | undefined> {
-    try {
-      const fetchOptions = await createFetchOptions(
-        BASE_URL,
-        {},
-        {
-          retries: options.retries,
-          signal: options.signal,
-          timeout: options.timeout ?? 60_000,
-        },
-      );
-      const response: unknown = await $fetch("/collinfo.json", fetchOptions);
-      return parseCollinfo(response);
-    } catch (error) {
-      consola.debug("[commoncrawl] collinfo.json fetch failed, using fallback:", error);
-      return undefined;
-    }
+  ): Promise<CrawlIndex> {
+    const fetchOptions = await createFetchOptions(
+      BASE_URL,
+      {},
+      {
+        retries: options.retries,
+        signal: options.signal,
+        timeout: options.timeout ?? 60_000,
+      },
+    );
+    const response: unknown = await $fetch("/collinfo.json", fetchOptions);
+    const index = parseCollinfo(response);
+    if (!index) throw new Error("Common Crawl collinfo.json returned no usable collection");
+    return index;
   }
 
   /**

--- a/test/commoncrawl.test.ts
+++ b/test/commoncrawl.test.ts
@@ -106,6 +106,30 @@ describe("Common Crawl", () => {
     );
   });
 
+  it("surfaces a collinfo fetch failure without querying a fake latest index", async () => {
+    vi.mocked($fetch).mockRejectedValueOnce(new Error("collinfo unavailable"));
+
+    const result = await createArchive(createCommonCrawl()).snapshots("example.com");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("collinfo unavailable");
+    expect($fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["an empty list", []],
+    ["a non-list response", {}],
+    ["an unusable entry", [{}]],
+  ])("rejects %s from collinfo without querying a fake latest index", async (_label, collInfo) => {
+    vi.mocked($fetch).mockResolvedValueOnce(collInfo);
+
+    const result = await createArchive(createCommonCrawl()).snapshots("example.com");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Common Crawl collinfo.json returned no usable collection");
+    expect($fetch).toHaveBeenCalledTimes(1);
+  });
+
   it("handles empty results", async () => {
     // CommonCrawl returns no data for empty results
     // Mock collection info then empty NDJSON


### PR DESCRIPTION
`CC-MAIN-latest-index` does not exist, so that fallback was only hiding the real `collinfo.json` failure behind a guaranteed second failure. Latest crawl discovery stops on the original error instead, and malformed metadata gets a useful error. Closes #54.