### PR TITLE
fix: preserve Archive.today capture URLs

### DIFF
--- a/src/providers/archive-today.ts
+++ b/src/providers/archive-today.ts
@@ -1,6 +1,5 @@
 import { consola } from "consola";
 import { $fetch } from "ofetch";
-import { cleanDoubleSlashes, withoutTrailingSlash } from "ufo";
 import type {
   ArchiveContentOptions,
   ArchiveContentResponse,
@@ -73,11 +72,11 @@ function archiveTodayPage(
       });
       return undefined;
     }
-    const normalizedOriginal = origUrl.includes("://") ? origUrl : `https://${origUrl}`;
+    const originalUrl = origUrl.includes("://") ? origUrl : `https://${origUrl}`;
     return {
-      url: withoutTrailingSlash(cleanDoubleSlashes(normalizedOriginal)),
+      url: originalUrl,
       timestamp: isoTimestamp,
-      snapshot: withoutTrailingSlash(snapshotUrl),
+      snapshot: snapshotUrl,
       _meta: { hash: timestamp, raw_date: datetime, position } as ArchiveTodayMetadata,
     };
   } catch (error) {
@@ -213,7 +212,9 @@ export class ArchiveTodayProvider extends BaseProvider<ArchiveTodayOptions> {
    * The timemap labels its newest row `last memento` and a lone capture
    * `first last memento`, so the match takes any first/last qualifiers;
    * requiring a bare `memento` would drop the newest capture from every
-   * listing.
+   * listing. Fully qualified URLs stay exactly as the timemap recorded them:
+   * scheme, duplicate path separators, and a trailing slash can all distinguish
+   * one archived resource from another.
 
    *
    * @param target - Target.
@@ -241,7 +242,7 @@ export class ArchiveTodayProvider extends BaseProvider<ArchiveTodayOptions> {
     // <http://archive.md/20140101030405/https://example.com/>; rel="memento"; datetime="Wed, 01 Jan 2014 03:04:05 GMT"
     const pages: ArchivedPage[] = [];
     const mementoRegex =
-      /<(https?:\/\/archive\.(?:is|today|md|ph)\/([0-9]{8,14})\/(?:https?:\/\/)?([^>]+))>;\s*rel="(?:(?:first|last)\s+)*memento";\s*datetime="([^"]+)"/g;
+      /<(https?:\/\/archive\.(?:is|today|md|ph)\/([0-9]{8,14})\/((?:https?:\/\/)?[^>]+))>;\s*rel="(?:(?:first|last)\s+)*memento";\s*datetime="([^"]+)"/g;
 
     let mementoMatch;
     let index = 0;

--- a/test/archive-today.test.ts
+++ b/test/archive-today.test.ts
@@ -36,8 +36,8 @@ describe("archive.today", () => {
     expect(result.pages).toHaveLength(4);
 
     // Check first snapshot
-    expect(result.pages[0].url).toBe("https://example.com");
-    expect(result.pages[0].snapshot).toBe("http://archive.md/20020120142510/http://example.com");
+    expect(result.pages[0].url).toBe("http://example.com/");
+    expect(result.pages[0].snapshot).toBe("http://archive.md/20020120142510/http://example.com/");
     expect(result.pages[0]._meta.hash).toBe("20020120142510");
     expect(result.pages[0]._meta.raw_date).toBe("Sun, 20 Jan 2002 14:25:10 GMT");
 
@@ -52,6 +52,22 @@ describe("archive.today", () => {
         timeout: 10000,
       }),
     );
+  });
+
+  it("preserves the original and snapshot URLs reported by the timemap", async () => {
+    const originalUrl = "http://example.com/path//?next=//cdn.example/";
+    const snapshotUrl = `http://archive.md/20140101030405/${originalUrl}`;
+    vi.mocked($fetch).mockResolvedValueOnce(
+      `<${snapshotUrl}>; rel="memento"; datetime="Wed, 01 Jan 2014 03:04:05 GMT"`,
+    );
+
+    const archive = createArchiveClient(createArchiveToday());
+    const result = await archive.snapshots("https://example.com/path//?next=//cdn.example/");
+
+    expect(result.success).toBe(true);
+    expect(result.pages).toHaveLength(1);
+    expect(result.pages[0].url).toBe(originalUrl);
+    expect(result.pages[0].snapshot).toBe(snapshotUrl);
   });
 
   /**

--- a/test/content.test.ts
+++ b/test/content.test.ts
@@ -455,7 +455,7 @@ describe("archive-today content", () => {
     fetchMock.mockResolvedValueOnce(timemap);
     rawMock.mockResolvedValueOnce(
       rawResponse("<html><body>archived profile</body></html>", {
-        url: "http://archive.md/20210326214327/https://example.com",
+        url: "http://archive.md/20210326214327/https://example.com/",
         headers: {
           "content-type": "text/html;charset=utf-8",
           "memento-datetime": "Fri, 26 Mar 2021 21:43:27 GMT",
@@ -466,12 +466,14 @@ describe("archive-today content", () => {
     const response = await createArchive(createArchiveToday()).content("example.com");
 
     expect(response.success).toBe(true);
-    expect(response.content?.url).toBe("https://example.com");
-    expect(response.content?.snapshot).toBe("http://archive.md/20210326214327/https://example.com");
+    expect(response.content?.url).toBe("https://example.com/");
+    expect(response.content?.snapshot).toBe(
+      "http://archive.md/20210326214327/https://example.com/",
+    );
     expect(response.content?.timestamp).toBe("2021-03-26T21:43:27Z");
     expect(response.content?.content).toContain("archived profile");
     expect(rawMock).toHaveBeenCalledWith(
-      "/20210326214327/https://example.com",
+      "/20210326214327/https://example.com/",
       objectContaining({ baseURL: "http://archive.md" }),
     );
   });
@@ -487,7 +489,7 @@ describe("archive-today content", () => {
     await createArchive(createArchiveToday()).content("example.com", { timestamp: "2020-12-31" });
 
     expect(rawMock).toHaveBeenCalledWith(
-      "/20200606060606/https://example.com",
+      "/20200606060606/https://example.com/",
       objectContaining({ baseURL: "http://archive.md" }),
     );
   });
@@ -507,7 +509,7 @@ describe("archive-today content", () => {
     expect(response.success).toBe(true);
     expect(fetchMock).toHaveBeenCalledWith("/timemap/http://example.com", expect.anything());
     expect(rawMock).toHaveBeenCalledWith(
-      "/20200606060606/https://example.com",
+      "/20200606060606/https://example.com/",
       objectContaining({ baseURL: "http://archive.md" }),
     );
   });
@@ -535,7 +537,9 @@ describe("archive-today content", () => {
 
     expect(response.success).toBe(true);
     expect(fetchMock).toHaveBeenCalledWith("/timemap/http://example.com", expect.anything());
-    expect(response.content?.snapshot).toBe("http://archive.md/20200606060606/https://example.com");
+    expect(response.content?.snapshot).toBe(
+      "http://archive.md/20200606060606/https://example.com/",
+    );
   });
 
   it("refuses a body that arrives without a Memento-Datetime header", async () => {


### PR DESCRIPTION
## Summary

- preserve the original scheme and trailing slash from Archive.today TimeMaps
- stop collapsing repeated separators in original and snapshot URLs
- keep content playback requests aligned with the snapshot URL the archive returned

## Why

`ArchivedPage.url` promises the original URL as the archive recorded it. The Archive.today parser dropped the captured URL scheme, rebuilt HTTP captures as HTTPS, and normalized both URLs. A live TimeMap row for `http://example.com/` was therefore exposed as `https://example.com` with a shortened playback URL. That can identify a different resource and makes the returned snapshot diverge from the archive response.

## Tests

- `pnpm test`
- built-package live probe against the Archive.today TimeMap for `example.com`