### PR TITLE
fix: don't drop providers added during resolution

### DIFF
--- a/src/archive.ts
+++ b/src/archive.ts
@@ -338,7 +338,7 @@ export class Archive implements ArchiveInterface {
   readonly options?: ArchiveOptions;
 
   private readonly providersInput: ProviderInput;
-  private resolvedProviders: ArchiveProvider[] | undefined;
+  private providerResolution: Promise<ArchiveProvider[]> | undefined;
 
   constructor(providers: ProviderInput, options?: Readonly<ArchiveOptions>) {
     this.providersInput = isProviderArray(providers) ? [...providers] : providers;
@@ -361,13 +361,14 @@ export class Archive implements ArchiveInterface {
    * @returns {Promise<ArchiveProvider[]>} A promise resolving to the operation result.
    */
   async resolveProviders(): Promise<ArchiveProvider[]> {
-    if (this.resolvedProviders) {
-      return [...this.resolvedProviders];
-    }
+    return [...(await this.resolveProviderList())];
+  }
 
-    const result = await Promise.resolve(this.providersInput);
-    this.resolvedProviders = isProviderArray(result) ? [...result] : [result];
-    return [...this.resolvedProviders];
+  private resolveProviderList(): Promise<ArchiveProvider[]> {
+    this.providerResolution ??= Promise.resolve(this.providersInput).then((result) =>
+      isProviderArray(result) ? [...result] : [result],
+    );
+    return this.providerResolution;
   }
 
   /**
@@ -714,8 +715,8 @@ export class Archive implements ArchiveInterface {
    */
   async use(provider: ProviderReference): Promise<ArchiveInterface> {
     const resolvedProvider = await Promise.resolve(provider);
-    const currentProviders = await this.resolveProviders();
-    this.resolvedProviders = [...currentProviders, resolvedProvider];
+    const currentProviders = await this.resolveProviderList();
+    currentProviders.push(resolvedProvider);
     return this;
   }
 
@@ -741,8 +742,8 @@ export class Archive implements ArchiveInterface {
    */
   async useAll(newProviders: readonly ProviderReference[]): Promise<ArchiveInterface> {
     const resolvedNewProviders = await Promise.all(newProviders.map((p) => Promise.resolve(p)));
-    const currentProviders = await this.resolveProviders();
-    this.resolvedProviders = [...currentProviders, ...resolvedNewProviders];
+    const currentProviders = await this.resolveProviderList();
+    currentProviders.push(...resolvedNewProviders);
     return this;
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -70,6 +70,16 @@ async function captureThrow(promise: Readonly<Promise<unknown>>): Promise<unknow
   throw new Error("expected promise to reject");
 }
 
+function deferred<T>() {
+  let resolve = (_value: T): void => {
+    throw new Error("Deferred promise was not initialized");
+  };
+  const promise = new Promise<T>((fulfill) => {
+    resolve = fulfill;
+  });
+  return { promise, resolve };
+}
+
 // --- factory ---
 
 describe("createArchive", () => {
@@ -124,6 +134,23 @@ describe("Archive.resolveProviders", () => {
 
     resolved.pop();
     await expect(archive.resolveProviders()).resolves.toHaveLength(2);
+  });
+
+  it("keeps providers added while the initial provider is still resolving", async () => {
+    const initial = deferred<ArchiveProvider>();
+    const archive = new Archive(initial.promise);
+    const additions = Promise.all([
+      archive.use(successProvider("one", [])),
+      archive.useAll([successProvider("two", [])]),
+    ]);
+
+    initial.resolve(successProvider("initial", []));
+    await additions;
+
+    const resolved = await archive.resolveProviders();
+    expect(new Set(resolved.map((provider) => provider.slug))).toEqual(
+      new Set(["initial", "one", "two"]),
+    );
   });
 });
 


### PR DESCRIPTION
Concurrent `use()` and `useAll()` calls while the initial provider list is still resolving each read their own snapshot, so one addition silently vanished. A probe with two additions and a pending initial provider kept only one. The fix shares one resolution promise and appends to the same list, so all three providers land.