### PR TITLE
fix: reject enum values outside tool schemas

### DIFF
--- a/src/tool-operations.ts
+++ b/src/tool-operations.ts
@@ -408,7 +408,7 @@ type ArchiveProviderOrList = Awaited<
  * @returns {ProviderName} The operation result.
  */
 export function normalizeProvider(provider: string | undefined): ProviderName {
-  const raw = (provider ?? "auto").trim() || "auto";
+  const raw = provider ?? "auto";
   const alias = PROVIDER_ALIASES[raw as keyof typeof PROVIDER_ALIASES];
   if (alias) return alias;
   if (!isKnownProvider(raw)) {
@@ -534,7 +534,7 @@ function buildSnapshotOptions(
  * @returns {ContentFormat} The operation result.
  */
 export function normalizeFormat(format: string | undefined): ContentFormat {
-  const raw = (format ?? "text").trim() || "text";
+  const raw = format ?? "text";
   if (!(CONTENT_FORMATS as readonly string[]).includes(raw)) {
     throw new Error(`Unknown format "${raw}". Available: ${CONTENT_FORMATS.join(", ")}.`);
   }

--- a/test/pi-extension.test.ts
+++ b/test/pi-extension.test.ts
@@ -21,6 +21,8 @@ import {
   PROVIDER_INPUTS,
   SNAPSHOT_FROM_HINT,
   SNAPSHOT_TO_HINT,
+  normalizeFormat,
+  normalizeProvider,
 } from "../src/tool-operations";
 import type { ArchiveContentResponse, ArchiveResponse } from "../src/types";
 
@@ -202,6 +204,15 @@ describe("Pi extension", () => {
       (properties["format"]?.["anyOf"] ?? []) as Array<{ const: string }>
     ).map((member) => member.const);
     expect(offeredFormats).toEqual([...CONTENT_FORMATS]);
+  });
+
+  it("rejects enum spellings hidden from the tool schemas", () => {
+    expect(normalizeProvider(undefined)).toBe("all");
+    expect(normalizeFormat(undefined)).toBe("text");
+    expect(() => normalizeProvider(" wayback ")).toThrow('Unknown provider " wayback "');
+    expect(() => normalizeProvider(" ")).toThrow('Unknown provider " "');
+    expect(() => normalizeFormat(" raw ")).toThrow('Unknown format " raw "');
+    expect(() => normalizeFormat(" ")).toThrow('Unknown format " "');
   });
 
   it("reads one capture through the shared executor", async () => {


### PR DESCRIPTION
` wayback ` and ` raw ` slipped through the shared executors even though every tool schema rejects them. The executors now accept the same values as the schemas, while missing values still default to `auto` and `text`.

Tested with `pnpm test` (260 tests).
