### PR TITLE
fix: restore provider labels on archive results

### DIFF
--- a/src/utils/_utils.ts
+++ b/src/utils/_utils.ts
@@ -200,7 +200,10 @@ export function createSuccessResponse(
 ): ArchiveResponse {
   return {
     success: true,
-    pages: [...pages],
+    pages: pages.map((page) => ({
+      ...page,
+      _meta: { ...page._meta, provider: source },
+    })),
     _meta: {
       source,
       provider: source,

--- a/test/archive-today.test.ts
+++ b/test/archive-today.test.ts
@@ -40,6 +40,7 @@ describe("archive.today", () => {
     expect(result.pages[0].snapshot).toBe("http://archive.md/20020120142510/http://example.com/");
     expect(result.pages[0]._meta.hash).toBe("20020120142510");
     expect(result.pages[0]._meta.raw_date).toBe("Sun, 20 Jan 2002 14:25:10 GMT");
+    expect(result.pages[0]._meta.provider).toBe("archive-today");
 
     // Verify API call
     expect($fetch).toHaveBeenCalledWith(

--- a/test/permacc.test.ts
+++ b/test/permacc.test.ts
@@ -72,6 +72,7 @@ describe("Perma.cc Platform", () => {
         title: "Example Page",
         status: "success",
         created_by: "1",
+        provider: "permacc",
       },
     });
     expect(result._meta?.meta).toEqual({

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  createSuccessResponse,
   mapCdxRows,
   normalizeDomain,
   processInParallel,
@@ -46,6 +47,27 @@ describe("processInParallel", () => {
     });
 
     expect(result).toEqual([2, 4]);
+  });
+});
+
+describe("createSuccessResponse", () => {
+  it("uses the response source as each page provider", () => {
+    const response = createSuccessResponse(
+      [
+        {
+          url: "https://example.com/",
+          timestamp: "2023-01-01T00:00:00Z",
+          snapshot: "https://archive.example/capture",
+          _meta: { digest: "example", provider: "stale-source" },
+        },
+      ],
+      "example-archive",
+    );
+
+    expect(response.pages[0]._meta).toEqual({
+      digest: "example",
+      provider: "example-archive",
+    });
   });
 });
 


### PR DESCRIPTION
Archive.today and Perma.cc pages reached combined results without a provider label, so their entries looked anonymous beside every other archive. A live Archive.today lookup confirmed it; `createSuccessResponse()` already knows the source and is the right place to stop that drift.