### PR TITLE
fix: keep query URLs distinct in content cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "citty": "0.2.2",
     "consola": "3.4.2",
     "ofetch": "1.5.1",
+    "ohash": "2.0.11",
     "typebox": "1.3.15",
     "ufo": "1.6.4",
     "unstorage": "1.17.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       ofetch:
         specifier: 1.5.1
         version: 1.5.1
+      ohash:
+        specifier: 2.0.11
+        version: 2.0.11
       typebox:
         specifier: 1.3.15
         version: 1.3.15

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,6 +1,7 @@
 import { createStorage, type Storage, type Driver } from "unstorage";
 import memoryDriver from "unstorage/drivers/memory";
 import { consola } from "consola";
+import { digest } from "ohash/crypto";
 import type {
   ArchiveContentOptions,
   ArchiveContentResponse,
@@ -15,6 +16,10 @@ export const storage: Storage = createStorage({
 
 let storagePrefix = "archives";
 let storageInitialized = false;
+
+function serializeStorageKey(providerKey: string, parts: readonly string[]): string {
+  return `${storagePrefix}:${digest(providerKey)}:${digest(JSON.stringify(parts))}`;
+}
 
 type StorageConfigOptions = Readonly<{
   driver?: Driver;
@@ -139,7 +144,7 @@ export function generateStorageKey(
   const providerKey = provider.slug ?? provider.name;
   const keyParts = [providerKey, domain, ...getCacheKeyParts(provider, options)];
 
-  return `${storagePrefix}:${JSON.stringify(keyParts)}`;
+  return serializeStorageKey(providerKey, keyParts);
 }
 
 async function restoreStoredResponse(
@@ -260,7 +265,7 @@ export function generateContentStorageKey(
   const providerCacheKey = provider.cacheKey?.(options);
   if (providerCacheKey) keyParts.push(providerCacheKey);
 
-  return `${storagePrefix}:${JSON.stringify(keyParts)}`;
+  return serializeStorageKey(providerKey, keyParts);
 }
 
 /**
@@ -364,7 +369,7 @@ export async function clearProviderStorage(
     }
 
     const providerKey = typeof provider === "string" ? provider : (provider.slug ?? provider.name);
-    const providerPrefix = `${storagePrefix}:[${JSON.stringify(providerKey)},`;
+    const providerPrefix = `${storagePrefix}:${digest(providerKey)}:`;
     const keys = await storage.getKeys();
 
     for (const key of keys) {

--- a/test/content.test.ts
+++ b/test/content.test.ts
@@ -3,7 +3,7 @@ import { gzipSync } from "node:zlib";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { $fetch, type FetchResponse } from "ofetch";
 import { createArchive, resetConfig, storage, UnsupportedOperationError } from "../src";
-import type { ArchiveContentResponse, ArchiveProvider } from "../src/types";
+import type { ArchiveContentOptions, ArchiveContentResponse, ArchiveProvider } from "../src/types";
 import createWayback from "../src/providers/wayback";
 import createCommonCrawl from "../src/providers/commoncrawl";
 import createArchiveToday from "../src/providers/archive-today";
@@ -380,6 +380,54 @@ describe("wayback content", () => {
 
     expect(second.fromCache).toBeUndefined();
     expect(second.content?.content).toBe("older");
+  });
+});
+
+describe("content cache", () => {
+  it("keeps query URLs and capture options in separate cache entries", async () => {
+    const read = vi.fn(
+      async (
+        url: string,
+        options?: Readonly<ArchiveContentOptions>,
+      ): Promise<ArchiveContentResponse> => ({
+        success: true,
+        content: {
+          url,
+          timestamp: options?.timestamp ?? "2020-01-01",
+          snapshot: `https://archive.test/${encodeURIComponent(url)}`,
+          content: `${url}:${options?.maxBytes}`,
+          bytes: options?.maxBytes ?? 0,
+          truncated: false,
+          _meta: { provider: "stub" },
+        },
+        _meta: { source: "stub", provider: "stub" },
+      }),
+    );
+    const archive = createArchive(stubProvider("stub", read));
+    const firstUrl = "https://example.test/app.js?id=aaa";
+    const secondUrl = "https://example.test/app.js?id=bbb";
+
+    const firstOptions = { timestamp: "2023-01-01", maxBytes: 64 } as const;
+    await archive.content(firstUrl, firstOptions);
+    const second = await archive.content(secondUrl, firstOptions);
+    const third = await archive.content(secondUrl, {
+      timestamp: "2024-01-01",
+      maxBytes: 128,
+    });
+    const repeated = await archive.content(secondUrl, firstOptions);
+
+    expect(second.fromCache).toBeUndefined();
+    expect(second.content?.url).toBe(secondUrl);
+    expect(third.fromCache).toBeUndefined();
+    expect(third.content).toMatchObject({
+      url: secondUrl,
+      timestamp: "2024-01-01",
+      content: `${secondUrl}:128`,
+    });
+    expect(repeated.fromCache).toBe(true);
+    expect(repeated.content?.content).toBe(`${secondUrl}:64`);
+    expect(read).toHaveBeenCalledTimes(3);
+    expect(await storage.getKeys()).toHaveLength(3);
   });
 });
 


### PR DESCRIPTION
Query URLs collapsing into one cache entry is silent provenance corruption: the next read can return another capture's body and timestamp. Cache dimensions are hashed before `unstorage` normalizes the key, keeping distinct URLs, timestamps and byte limits apart. Closes #66.