### PR TITLE
fix: fail fast on invalid processing limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,16 +430,16 @@ Returns:
 
 All methods accept `ArchiveOptions`:
 
-| Option        | Type      | Default     | Description                          |
-| ------------- | --------- | ----------- | ------------------------------------ |
-| `limit`       | `number`  | `1000`      | Maximum results to return            |
-| `cache`       | `boolean` | `true`      | Enable/disable caching               |
-| `ttl`         | `number`  | `604800000` | Cache TTL in milliseconds (7 days)   |
-| `concurrency` | `number`  | `3`         | Max parallel requests                |
-| `batchSize`   | `number`  | `20`        | Items per processing batch           |
-| `timeout`     | `number`  | `10000`     | Request timeout in ms                |
-| `retries`     | `number`  | `1`         | Retry attempts on failure            |
-| `apiKey`      | `string`  | -           | API key for providers that need auth |
+| Option        | Type      | Default     | Description                             |
+| ------------- | --------- | ----------- | --------------------------------------- |
+| `limit`       | `number`  | `1000`      | Maximum results to return               |
+| `cache`       | `boolean` | `true`      | Enable/disable caching                  |
+| `ttl`         | `number`  | `604800000` | Cache TTL in milliseconds (7 days)      |
+| `concurrency` | `number`  | `3`         | Positive integer; max parallel requests |
+| `batchSize`   | `number`  | `20`        | Positive integer; items per batch       |
+| `timeout`     | `number`  | `10000`     | Request timeout in ms                   |
+| `retries`     | `number`  | `1`         | Retry attempts on failure               |
+| `apiKey`      | `string`  | -           | API key for providers that need auth    |
 
 `content()` takes two more, in `ArchiveContentOptions`:
 

--- a/docs/content/1.guide/5.configuration.md
+++ b/docs/content/1.guide/5.configuration.md
@@ -24,7 +24,7 @@ export default {
 };
 ```
 
-Overrides per environment live under `$development`, `$production` and `$test`. `getConfig()` returns the resolved object, `resetConfig()` drops the cache, `resolveConfig({ cwd })` loads from somewhere else without caching.
+Overrides per environment live under `$development`, `$production` and `$test`. `getConfig()` returns the resolved object, `resetConfig()` drops the cache, `resolveConfig({ cwd })` loads from somewhere else without caching. `concurrency` and `batchSize` must be positive integers; invalid values fail before processing starts.
 
 ## Cache
 

--- a/src/utils/_utils.ts
+++ b/src/utils/_utils.ts
@@ -15,6 +15,13 @@ import { getConfig } from "../config";
 
 const ALLOWED_WAYBACK_TIMESTAMP_LENGTHS = new Set([4, 6, 8, 10, 12, 14]);
 
+function requirePositiveInteger(value: unknown, name: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+    throw new RangeError(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
 // Utility for parallel processing with concurrency control
 export async function processInParallel<T, R>(
   items: readonly T[],
@@ -22,8 +29,14 @@ export async function processInParallel<T, R>(
   options: Readonly<{ concurrency?: number; batchSize?: number }> = {},
 ): Promise<R[]> {
   const config = await getConfig();
-  const concurrency = options.concurrency ?? config.performance.concurrency ?? 3;
-  const batchSize = options.batchSize ?? config.performance.batchSize ?? 20;
+  const concurrency = requirePositiveInteger(
+    options.concurrency ?? config.performance.concurrency ?? 3,
+    "concurrency",
+  );
+  const batchSize = requirePositiveInteger(
+    options.batchSize ?? config.performance.batchSize ?? 20,
+    "batchSize",
+  );
 
   // Process small datasets directly
   if (items.length <= concurrency) {
@@ -471,11 +484,16 @@ export async function mergeOptions<T extends ArchiveOptions>(
   };
 
   // Create merged options with all properties preserved
-  return {
+  const merged = {
     ...defaultOptions,
     ...initOptions,
     ...reqOptions,
   } as T;
+
+  requirePositiveInteger(merged.concurrency ?? config.performance.concurrency ?? 3, "concurrency");
+  requirePositiveInteger(merged.batchSize ?? config.performance.batchSize ?? 20, "batchSize");
+
+  return merged;
 }
 
 /**
@@ -494,7 +512,10 @@ export async function mapCdxRows(
 ): Promise<ArchivedPage[]> {
   const config = await getConfig();
 
-  const batchSize = options.batchSize ?? config.performance.batchSize ?? 20;
+  const batchSize = requirePositiveInteger(
+    options.batchSize ?? config.performance.batchSize ?? 20,
+    "batchSize",
+  );
 
   // For small datasets, process directly without batching
   if (dataRows.length <= batchSize) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -111,6 +111,19 @@ describe("createArchive", () => {
     );
   });
 
+  it.each([
+    ["concurrency", { concurrency: 0 }],
+    ["batchSize", { batchSize: 0 }],
+  ] as const)("rejects invalid %s before calling a single provider", async (name, options) => {
+    const provider = successProvider("unused", []);
+    const archive = createArchive(provider, options);
+
+    await expect(archive.snapshots("example.com")).rejects.toThrow(
+      `${name} must be a positive integer`,
+    );
+    expect(provider.snapshots).not.toHaveBeenCalled();
+  });
+
   it("keeps snapshots callable when passed as a callback", async () => {
     const archive = createArchive(successProvider("callback", []), { cache: false });
     /* oxlint-disable-next-line typescript/unbound-method -- extraction is the behavior under test; Archive binds this method. */

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -52,6 +52,24 @@ describe("processInParallel", () => {
 
     expect(result).toEqual([2, 4]);
   });
+
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    "rejects invalid concurrency %s",
+    async (concurrency) => {
+      await expect(processInParallel([1, 2], async (n) => n, { concurrency })).rejects.toThrow(
+        "concurrency must be a positive integer",
+      );
+    },
+  );
+
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    "rejects invalid batch size %s",
+    async (batchSize) => {
+      await expect(
+        processInParallel([1, 2], async (n) => n, { concurrency: 1, batchSize }),
+      ).rejects.toThrow("batchSize must be a positive integer");
+    },
+  );
 });
 
 describe("withUserAgent", () => {
@@ -154,6 +172,20 @@ describe("waybackTimestampToISO", () => {
 });
 
 describe("mapCdxRows", () => {
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    "rejects invalid batch size %s",
+    async (batchSize) => {
+      await expect(
+        mapCdxRows(
+          [["https://example.com/", "20220101120000", "200"]],
+          "https://archive.test",
+          "test",
+          { batchSize },
+        ),
+      ).rejects.toThrow("batchSize must be a positive integer");
+    },
+  );
+
   it("returns empty array for empty input", async () => {
     const pages = await mapCdxRows([], "https://web.archive.org/web", "wayback", { batchSize: 50 });
     expect(pages).toEqual([]);


### PR DESCRIPTION
Bad config should not freeze the whole request. `batchSize: 0` could loop forever and `NaN` could silently drop work. Invalid `concurrency` and `batchSize` are rejected before any provider runs.