### PR TITLE
fix: keep archived redirects from going live

### DIFF
--- a/src/providers/archive-it.ts
+++ b/src/providers/archive-it.ts
@@ -189,6 +189,7 @@ export class ArchiveItProvider extends BaseProvider<ArchiveItOptions> {
         original: capture.original,
         stamp: capture.timestamp,
         provider: "archive-it",
+        captureStatus: capture.status,
         options,
         meta: { collection },
       });

--- a/src/providers/archive-today.ts
+++ b/src/providers/archive-today.ts
@@ -29,6 +29,22 @@ interface ArchiveTodayCapture {
   timestamp: string;
 }
 
+const ARCHIVE_TODAY_HOST = /^archive\.(?:fo|is|li|md|ph|today|vn)$/iu;
+const ARCHIVE_TODAY_CAPTURE_PATH = /^\/\d{8,14}\/[^/]/u;
+const ARCHIVE_TODAY_PLAYBACK_POLICY = {
+  assertURL(url: URL) {
+    if (
+      (url.protocol !== "http:" && url.protocol !== "https:") ||
+      url.username ||
+      url.password ||
+      !ARCHIVE_TODAY_HOST.test(url.hostname) ||
+      !ARCHIVE_TODAY_CAPTURE_PATH.test(url.pathname)
+    ) {
+      throw new Error("Archive.today playback left its capture endpoint");
+    }
+  },
+} as const;
+
 function selectArchiveTodayCapture(
   pages: readonly ArchivedPage[],
   requestedUrl: string,
@@ -171,6 +187,7 @@ export class ArchiveTodayProvider extends BaseProvider<ArchiveTodayOptions> {
         snapshotUrl.origin,
         `${snapshotUrl.pathname}${snapshotUrl.search}`,
         options,
+        ARCHIVE_TODAY_PLAYBACK_POLICY,
       );
       if (!body.capturedAt) {
         throw new Error(

--- a/src/providers/arquivo.ts
+++ b/src/providers/arquivo.ts
@@ -246,6 +246,7 @@ export class ArquivoProvider extends BaseProvider<ArquivoOptions> {
         original: capture.url,
         stamp: capture.timestamp,
         provider: "arquivo",
+        captureStatus: capture.status,
         options,
       });
       return createContentResponse(decoratePlayback(playback, capture), "arquivo", {

--- a/src/providers/wayback.ts
+++ b/src/providers/wayback.ts
@@ -167,6 +167,7 @@ export class WaybackProvider extends BaseProvider<WaybackOptions> {
         original: capture.original,
         stamp: capture.timestamp,
         provider: "wayback",
+        captureStatus: capture.status,
         options,
       });
 

--- a/src/providers/webarchiv.ts
+++ b/src/providers/webarchiv.ts
@@ -227,6 +227,7 @@ export class WebarchivProvider extends BaseProvider<WebarchivOptions> {
         original: capture.url,
         stamp: capture.timestamp,
         provider: "webarchiv",
+        captureStatus: capture.status,
         options,
         policy: REPLAY_POLICY,
       });

--- a/src/providers/webarchiv.ts
+++ b/src/providers/webarchiv.ts
@@ -34,6 +34,7 @@ const REPLAY_POLICY = {
       throw new Error("Webarchiv Österreich replay left its raw playback endpoint");
     }
   },
+  returnRejectedRedirect: true,
 } satisfies FetchBodyPolicy;
 
 interface WebarchivCapture {

--- a/src/utils/_content.ts
+++ b/src/utils/_content.ts
@@ -325,6 +325,8 @@ export interface FetchedBody {
 export interface FetchBodyPolicy {
   assertURL(url: URL): void;
   maxRedirects?: number;
+  /** Return the redirect response itself when its destination fails validation. */
+  returnRejectedRedirect?: boolean;
 }
 
 type FetchBodyOptions = Readonly<ArchiveContentOptions> & {
@@ -343,6 +345,31 @@ type PlaybackCaptureRequest = Readonly<{
 }>;
 
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const RAW_CAPTURE_PATH = /^\d{4,14}id_\/https?:\/\//iu;
+
+function rawPlaybackPolicy(baseURL: string, prefix: string): FetchBodyPolicy {
+  const origin = new URL(baseURL).origin;
+  const pathPrefix = `${prefix.replace(/\/$/u, "")}/`;
+
+  return {
+    assertURL(url: URL) {
+      const capturePath = url.pathname.startsWith(pathPrefix)
+        ? url.pathname.slice(pathPrefix.length)
+        : "";
+      if (
+        url.origin !== origin ||
+        url.username ||
+        url.password ||
+        !RAW_CAPTURE_PATH.test(capturePath)
+      ) {
+        throw new Error("Archive playback left its raw capture endpoint");
+      }
+    },
+    // A redirect outside the playback endpoint is the response the archived
+    // site sent. Return that historical stub instead of visiting it today.
+    returnRejectedRedirect: true,
+  };
+}
 
 /* Converts one final raw response into the bounded body contract. */
 async function decodeFetchedResponse(
@@ -364,7 +391,7 @@ async function decodeFetchedResponse(
   };
 }
 
-async function fetchUncheckedBody(
+async function fetchUnredirectedBody(
   baseURL: string,
   path: string,
   options: Readonly<FetchBodyOptions>,
@@ -375,6 +402,7 @@ async function fetchUncheckedBody(
     {},
     {
       responseType: "stream",
+      redirect: "manual",
       retries: options.retries,
       signal: options.signal,
       timeout: options.timeout,
@@ -385,18 +413,13 @@ async function fetchUncheckedBody(
   return decodeFetchedResponse(response, maxBytes, `${baseURL}${path}`);
 }
 
-async function redirectDestination(
-  response: FetchResponse<unknown>,
-  current: URL,
-  redirectCount: number,
-  maxRedirects: number,
-): Promise<URL> {
+async function cancelResponseBody(response: FetchResponse<unknown>): Promise<void> {
   if (isReadableStream(response._data)) {
     await response._data.cancel().catch(() => undefined);
   }
-  if (redirectCount >= maxRedirects) {
-    throw new Error(`Archive playback exceeded ${maxRedirects} redirects`);
-  }
+}
+
+function redirectDestination(response: FetchResponse<unknown>, current: URL): URL {
   const location = headerValue(response.headers, "location");
   if (!location) throw new Error("Archive playback redirected without a Location header");
   return new URL(location, current);
@@ -429,7 +452,24 @@ async function fetchPolicyBody(
     if (!REDIRECT_STATUSES.has(response.status)) {
       return decodeFetchedResponse(response, maxBytes, current.href);
     }
-    current = await redirectDestination(response, current, redirectCount, maxRedirects);
+    if (redirectCount >= maxRedirects) {
+      await cancelResponseBody(response);
+      throw new Error(`Archive playback exceeded ${maxRedirects} redirects`);
+    }
+
+    let destination: URL;
+    try {
+      destination = redirectDestination(response, current);
+      policy.assertURL(destination);
+    } catch (error) {
+      if (policy.returnRejectedRedirect) {
+        return decodeFetchedResponse(response, maxBytes, current.href);
+      }
+      await cancelResponseBody(response);
+      throw error;
+    }
+    await cancelResponseBody(response);
+    current = destination;
   }
 }
 
@@ -438,8 +478,9 @@ async function fetchPolicyBody(
  *
  * The body is streamed rather than buffered so the cap is a real one: an
  * archived 60 MB video must not be pulled into memory to be thrown away.
- * A policy switches redirects to manual handling so every destination can be
- * checked before the network request rather than only after it has happened.
+ * Redirects are never followed implicitly. Without a policy the recorded
+ * redirect response is returned; with one, every destination is checked before
+ * its network request.
  *
  * @param baseURL - Origin of the archive endpoint
  * @param path - Path to request, already URL-shaped
@@ -458,7 +499,7 @@ export async function fetchBody(
   const maxBytes = resolveMaxBytes(options);
   return policy
     ? fetchPolicyBody(baseURL, path, options, policy, maxBytes)
-    : fetchUncheckedBody(baseURL, path, options, maxBytes);
+    : fetchUnredirectedBody(baseURL, path, options, maxBytes);
 }
 
 /**
@@ -481,7 +522,7 @@ export async function readPlaybackCapture(
     baseURL,
     `${prefix}/${stamp}id_/${original}`,
     options,
-    params.policy,
+    params.policy ?? rawPlaybackPolicy(baseURL, prefix),
   );
 
   // A playback request for a timestamp the archive does not hold redirects to

--- a/src/utils/_content.ts
+++ b/src/utils/_content.ts
@@ -339,6 +339,7 @@ type PlaybackCaptureRequest = Readonly<{
   original: string;
   stamp: string;
   provider: string;
+  captureStatus?: number;
   options: Readonly<ArchiveContentOptions>;
   meta?: Readonly<Record<string, unknown>>;
   policy?: Readonly<FetchBodyPolicy>;
@@ -518,12 +519,12 @@ export async function readPlaybackCapture(
   params: PlaybackCaptureRequest,
 ): Promise<ArchivedContent> {
   const { baseURL, prefix, original, stamp, provider, options } = params;
-  const body = await fetchBody(
-    baseURL,
-    `${prefix}/${stamp}id_/${original}`,
-    options,
-    params.policy ?? rawPlaybackPolicy(baseURL, prefix),
-  );
+  const capturedRedirect =
+    params.captureStatus !== undefined && REDIRECT_STATUSES.has(params.captureStatus);
+  const policy = capturedRedirect
+    ? undefined
+    : (params.policy ?? rawPlaybackPolicy(baseURL, prefix));
+  const body = await fetchBody(baseURL, `${prefix}/${stamp}id_/${original}`, options, policy);
 
   // A playback request for a timestamp the archive does not hold redirects to
   // the capture it does hold, so the served URL is the honest one to report.

--- a/test/content.test.ts
+++ b/test/content.test.ts
@@ -135,6 +135,10 @@ describe("wayback content", () => {
     ["another host", "http://127.0.0.1/private"],
     ["a non-capture path", "https://web.archive.org/private"],
     [
+      "a rewritten raw destination",
+      "https://web.archive.org/web/20200202000000id_/https://destination.example/",
+    ],
+    [
       "URL credentials",
       "https://user:secret@web.archive.org/web/20200202000000id_/https://example.com/",
     ],

--- a/test/content.test.ts
+++ b/test/content.test.ts
@@ -9,7 +9,7 @@ import createCommonCrawl from "../src/providers/commoncrawl";
 import createArchiveToday from "../src/providers/archive-today";
 import createWebcite from "../src/providers/webcite";
 import createArchiveIt from "../src/providers/archive-it";
-import { htmlToText, unwrapSnapshotUrl } from "../src/utils";
+import { fetchBody, htmlToText, unwrapSnapshotUrl } from "../src/utils";
 
 vi.mock("ofetch", () => {
   const raw = vi.fn();
@@ -73,6 +73,25 @@ beforeEach(async () => {
   vi.resetAllMocks();
 });
 
+describe("bounded body fetches", () => {
+  it("returns a redirect response instead of following it without a policy", async () => {
+    rawMock.mockResolvedValueOnce(
+      rawResponse("", {
+        status: 302,
+        url: "https://archive.example/capture",
+        headers: { location: "http://127.0.0.1/private" },
+      }),
+    );
+
+    const body = await fetchBody("https://archive.example", "/capture");
+
+    expect(body.status).toBe(302);
+    expect(body.url).toBe("https://archive.example/capture");
+    expect(rawMock).toHaveBeenCalledTimes(1);
+    expect(rawMock.mock.calls[0]?.[1]).toMatchObject({ redirect: "manual" });
+  });
+});
+
 describe("wayback content", () => {
   it("reads the newest capture through the id_ playback modifier", async () => {
     fetchMock.mockResolvedValueOnce(
@@ -110,6 +129,59 @@ describe("wayback content", () => {
     expect(fetchMock.mock.calls[0][1]).toMatchObject({
       params: objectContaining({ limit: "-5", url: "example.com" }),
     });
+  });
+
+  it.each([
+    ["another host", "http://127.0.0.1/private"],
+    ["a non-capture path", "https://web.archive.org/private"],
+    [
+      "URL credentials",
+      "https://user:secret@web.archive.org/web/20200202000000id_/https://example.com/",
+    ],
+  ])("does not follow an archived redirect to %s", async (_case, location) => {
+    fetchMock.mockResolvedValueOnce(cdxRows([["https://example.com/", "20200202000000", "302"]]));
+    rawMock.mockResolvedValueOnce(
+      rawResponse("", {
+        status: 302,
+        url: "https://web.archive.org/web/20200202000000id_/https://example.com/",
+        headers: { location },
+      }),
+    );
+
+    const response = await createArchive(createWayback()).content("example.com", {
+      timestamp: "20200202000000",
+    });
+
+    expect(response.success).toBe(true);
+    expect(response.content?._meta.status).toBe(302);
+    expect(rawMock).toHaveBeenCalledTimes(1);
+    expect(rawMock.mock.calls[0]?.[1]).toMatchObject({ redirect: "manual" });
+  });
+
+  it("follows a playback redirect that stays on the archive's raw endpoint", async () => {
+    fetchMock.mockResolvedValueOnce(cdxRows([["https://example.com/", "20200202000000", "200"]]));
+    rawMock
+      .mockResolvedValueOnce(
+        rawResponse("", {
+          status: 302,
+          url: "https://web.archive.org/web/20200202000000id_/https://example.com/",
+          headers: {
+            location: "/web/20200303000000id_/https://example.com/",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        rawResponse("redirected capture", {
+          url: "https://web.archive.org/web/20200303000000id_/https://example.com/",
+        }),
+      );
+
+    const response = await createArchive(createWayback()).content("example.com");
+
+    expect(response.success).toBe(true);
+    expect(response.content?.content).toBe("redirected capture");
+    expect(response.content?.timestamp).toBe("2020-03-03T00:00:00Z");
+    expect(rawMock).toHaveBeenCalledTimes(2);
   });
 
   it("skips a failed capture in favour of the nearest successful one", async () => {
@@ -588,6 +660,56 @@ describe("archive-today content", () => {
     expect(response.content?.snapshot).toBe(
       "http://archive.md/20200606060606/https://example.com/",
     );
+  });
+
+  it("follows a capture redirect between Archive.today aliases", async () => {
+    fetchMock.mockResolvedValueOnce(timemap);
+    rawMock
+      .mockResolvedValueOnce(
+        rawResponse("", {
+          status: 302,
+          url: "http://archive.md/20210326214327/https://example.com/",
+          headers: {
+            location: "https://archive.fo/20210326214327/https://example.com/",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        rawResponse("<html>aliased capture</html>", {
+          url: "https://archive.fo/20210326214327/https://example.com/",
+          headers: { "memento-datetime": "Fri, 26 Mar 2021 21:43:27 GMT" },
+        }),
+      );
+
+    const response = await createArchive(createArchiveToday()).content("example.com");
+
+    expect(response.success).toBe(true);
+    expect(response.content?.content).toBe("<html>aliased capture</html>");
+    expect(rawMock.mock.calls[1]?.[1]).toMatchObject({
+      baseURL: "https://archive.fo",
+      redirect: "manual",
+    });
+  });
+
+  it.each([
+    ["another host", "http://127.0.0.1/private"],
+    ["a deceptive hostname", "https://archive.is.evil.example/20210326214327/example.com"],
+    ["a non-capture path", "https://archive.is/error/403"],
+  ])("refuses an Archive.today redirect to %s", async (_case, location) => {
+    fetchMock.mockResolvedValueOnce(timemap);
+    rawMock.mockResolvedValueOnce(
+      rawResponse("", {
+        status: 302,
+        url: "http://archive.md/20210326214327/https://example.com/",
+        headers: { location },
+      }),
+    );
+
+    const response = await createArchive(createArchiveToday()).content("example.com");
+
+    expect(response.success).toBe(false);
+    expect(response.error).toBe("Archive.today playback left its capture endpoint");
+    expect(rawMock).toHaveBeenCalledTimes(1);
   });
 
   it("refuses a body that arrives without a Memento-Datetime header", async () => {

--- a/test/webarchiv.test.ts
+++ b/test/webarchiv.test.ts
@@ -226,7 +226,7 @@ describe("Webarchiv Österreich", () => {
     expect(secondOptions.params).not.toHaveProperty("reverse");
   });
 
-  it("does not follow a replay redirect outside Webarchiv Österreich", async () => {
+  it("returns a recorded redirect outside Webarchiv Österreich without following it", async () => {
     fetchMock.mockResolvedValueOnce(cdx("20200203040506"));
     rawMock.mockResolvedValueOnce(
       rawResponse("", {
@@ -240,12 +240,12 @@ describe("Webarchiv Österreich", () => {
       timestamp: "20200203040506",
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toBe("Webarchiv Österreich replay left its raw playback endpoint");
+    expect(result.success).toBe(true);
+    expect(result.content?._meta.status).toBe(302);
     expect(rawMock).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects a redirect on the same origin when it leaves the replay endpoint", async () => {
+  it("returns a redirect that leaves the replay path without following it", async () => {
     fetchMock.mockResolvedValueOnce(cdx("20200203040506"));
     rawMock
       .mockResolvedValueOnce(
@@ -265,8 +265,8 @@ describe("Webarchiv Österreich", () => {
       timestamp: "20200203040506",
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toBe("Webarchiv Österreich replay left its raw playback endpoint");
+    expect(result.success).toBe(true);
+    expect(result.content?._meta.status).toBe(302);
     expect(rawMock).toHaveBeenCalledTimes(1);
   });
 

--- a/test/webarchiv.test.ts
+++ b/test/webarchiv.test.ts
@@ -227,7 +227,9 @@ describe("Webarchiv Österreich", () => {
   });
 
   it("returns a recorded redirect outside Webarchiv Österreich without following it", async () => {
-    fetchMock.mockResolvedValueOnce(cdx("20200203040506"));
+    fetchMock.mockResolvedValueOnce(
+      cdx("20200203040506", "https://www.onb.ac.at/", { status: "302" }),
+    );
     rawMock.mockResolvedValueOnce(
       rawResponse("", {
         status: 302,
@@ -246,7 +248,9 @@ describe("Webarchiv Österreich", () => {
   });
 
   it("returns a redirect that leaves the replay path without following it", async () => {
-    fetchMock.mockResolvedValueOnce(cdx("20200203040506"));
+    fetchMock.mockResolvedValueOnce(
+      cdx("20200203040506", "https://www.onb.ac.at/", { status: "302" }),
+    );
     rawMock
       .mockResolvedValueOnce(
         rawResponse("", {


### PR DESCRIPTION
Raw playback was turning an archived `Location` header into a live server request. That's a nasty surprise for an archive reader. Capture moves inside each archive still work, while a page's own redirect stays historical; live checks against Wayback, Arquivo, and Archive-It still returned the requested bodies.